### PR TITLE
refactor: rename exo__ to core__ for self-contained ontology

### DIFF
--- a/03 Knowledge/application/!application.md
+++ b/03 Knowledge/application/!application.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_uid: d4e5f6a7-app0-0001-0000-000000000001
-exo__Asset_label: Application Layer
-exo__Asset_description: Слой приложения - команды, формы и процессы
-exo__Instance_class:
-  - "[[exo__Ontology]]"
+core__Asset_uid: d4e5f6a7-app0-0001-0000-000000000001
+core__Asset_label: Application Layer
+core__Asset_description: Слой приложения - команды, формы и процессы
+core__Instance_class:
+  - "[[core__Ontology]]"
 uri: https://exocortex.my/ontology/application#
 prefix: app
 ---

--- a/03 Knowledge/application/commands/!commands.md
+++ b/03 Knowledge/application/commands/!commands.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_uid: d4e5f6a7-cmd0-0001-0000-000000000001
-exo__Asset_label: Commands Ontology
-exo__Asset_description: Определение команд (Use Cases) системы
-exo__Instance_class:
-  - "[[exo__Ontology]]"
+core__Asset_uid: d4e5f6a7-cmd0-0001-0000-000000000001
+core__Asset_label: Commands Ontology
+core__Asset_description: Определение команд (Use Cases) системы
+core__Instance_class:
+  - "[[core__Ontology]]"
 uri: https://exocortex.my/ontology/application/commands#
 prefix: cmd
 ---

--- a/03 Knowledge/application/commands/cmd__Command.md
+++ b/03 Knowledge/application/commands/cmd__Command.md
@@ -1,8 +1,8 @@
 ---
-exo__Asset_uid: d4e5f6a7-cmd0-0002-0000-000000000001
-exo__Asset_isDefinedBy: "[[!commands]]"
-exo__Instance_class:
-  - "[[exo__Class]]"
-exo__Class_abstract: true
-exo__Class_description: Базовый класс для всех команд (Use Cases)
+core__Asset_uid: d4e5f6a7-cmd0-0002-0000-000000000001
+core__Asset_isDefinedBy: "[[!commands]]"
+core__Instance_class:
+  - "[[core__Class]]"
+core__Class_abstract: true
+core__Class_description: Базовый класс для всех команд (Use Cases)
 ---

--- a/03 Knowledge/application/commands/cmd__Command_category.md
+++ b/03 Knowledge/application/commands/cmd__Command_category.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_isDefinedBy: "[[!commands]]"
-exo__Asset_uid: a1b2c3d4-4444-4000-8000-000000000003
-exo__Instance_class:
-  - "[[exo__StringProperty]]"
-exo__Property_domain: "[[cmd__Command]]"
-exo__Asset_description: Категория команды для группировки в UI
+core__Asset_isDefinedBy: "[[!commands]]"
+core__Asset_uid: a1b2c3d4-4444-4000-8000-000000000003
+core__Instance_class:
+  - "[[core__StringProperty]]"
+core__Property_domain: "[[cmd__Command]]"
+core__Asset_description: Категория команды для группировки в UI
 ---
 

--- a/03 Knowledge/application/commands/cmd__Command_contextType.md
+++ b/03 Knowledge/application/commands/cmd__Command_contextType.md
@@ -1,10 +1,10 @@
 ---
-exo__Asset_isDefinedBy: "[[!commands]]"
-exo__Asset_uid: a1b2c3d4-4444-4000-8000-000000000005
-exo__Instance_class:
-  - "[[exo__ObjectProperty]]"
-exo__Property_domain: "[[cmd__Command]]"
-exo__Property_range: "[[meta__Class]]"
-exo__Asset_description: Тип контекста, в котором доступна команда (null = всегда доступна)
+core__Asset_isDefinedBy: "[[!commands]]"
+core__Asset_uid: a1b2c3d4-4444-4000-8000-000000000005
+core__Instance_class:
+  - "[[core__ObjectProperty]]"
+core__Property_domain: "[[cmd__Command]]"
+core__Property_range: "[[meta__Class]]"
+core__Asset_description: Тип контекста, в котором доступна команда (null = всегда доступна)
 ---
 

--- a/03 Knowledge/application/commands/cmd__Command_description.md
+++ b/03 Knowledge/application/commands/cmd__Command_description.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_isDefinedBy: "[[!commands]]"
-exo__Asset_uid: a1b2c3d4-4444-4000-8000-000000000002
-exo__Instance_class:
-  - "[[exo__StringProperty]]"
-exo__Property_domain: "[[cmd__Command]]"
-exo__Asset_description: Человекочитаемое описание команды
+core__Asset_isDefinedBy: "[[!commands]]"
+core__Asset_uid: a1b2c3d4-4444-4000-8000-000000000002
+core__Instance_class:
+  - "[[core__StringProperty]]"
+core__Property_domain: "[[cmd__Command]]"
+core__Asset_description: Человекочитаемое описание команды
 ---
 

--- a/03 Knowledge/application/commands/cmd__Command_form.md
+++ b/03 Knowledge/application/commands/cmd__Command_form.md
@@ -1,10 +1,10 @@
 ---
-exo__Asset_isDefinedBy: "[[!commands]]"
-exo__Asset_uid: a1b2c3d4-4444-4000-8000-000000000006
-exo__Instance_class:
-  - "[[exo__ObjectProperty]]"
-exo__Property_domain: "[[cmd__Command]]"
-exo__Property_range: "[[form__Form]]"
-exo__Asset_description: Форма для ввода параметров команды
+core__Asset_isDefinedBy: "[[!commands]]"
+core__Asset_uid: a1b2c3d4-4444-4000-8000-000000000006
+core__Instance_class:
+  - "[[core__ObjectProperty]]"
+core__Property_domain: "[[cmd__Command]]"
+core__Property_range: "[[form__Form]]"
+core__Asset_description: Форма для ввода параметров команды
 ---
 

--- a/03 Knowledge/application/commands/cmd__Command_hotkey.md
+++ b/03 Knowledge/application/commands/cmd__Command_hotkey.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_isDefinedBy: "[[!commands]]"
-exo__Asset_uid: a1b2c3d4-4444-4000-8000-000000000004
-exo__Instance_class:
-  - "[[exo__StringProperty]]"
-exo__Property_domain: "[[cmd__Command]]"
-exo__Asset_description: Горячая клавиша по умолчанию (например "Cmd+Shift+T")
+core__Asset_isDefinedBy: "[[!commands]]"
+core__Asset_uid: a1b2c3d4-4444-4000-8000-000000000004
+core__Instance_class:
+  - "[[core__StringProperty]]"
+core__Property_domain: "[[cmd__Command]]"
+core__Asset_description: Горячая клавиша по умолчанию (например "Cmd+Shift+T")
 ---
 

--- a/03 Knowledge/application/commands/cmd__Command_name.md
+++ b/03 Knowledge/application/commands/cmd__Command_name.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_isDefinedBy: "[[!commands]]"
-exo__Asset_uid: a1b2c3d4-4444-4000-8000-000000000001
-exo__Instance_class:
-  - "[[exo__StringProperty]]"
-exo__Property_domain: "[[cmd__Command]]"
-exo__Asset_description: Идентификатор команды (camelCase)
+core__Asset_isDefinedBy: "[[!commands]]"
+core__Asset_uid: a1b2c3d4-4444-4000-8000-000000000001
+core__Instance_class:
+  - "[[core__StringProperty]]"
+core__Property_domain: "[[cmd__Command]]"
+core__Asset_description: Идентификатор команды (camelCase)
 ---
 

--- a/03 Knowledge/application/commands/cmd__Command_targetType.md
+++ b/03 Knowledge/application/commands/cmd__Command_targetType.md
@@ -1,10 +1,10 @@
 ---
-exo__Asset_isDefinedBy: "[[!commands]]"
-exo__Asset_uid: a1b2c3d4-4444-4000-8000-000000000007
-exo__Instance_class:
-  - "[[exo__ObjectProperty]]"
-exo__Property_domain: "[[cmd__Command]]"
-exo__Property_range: "[[meta__Class]]"
-exo__Asset_description: Тип сущности, которую создаёт/изменяет команда
+core__Asset_isDefinedBy: "[[!commands]]"
+core__Asset_uid: a1b2c3d4-4444-4000-8000-000000000007
+core__Instance_class:
+  - "[[core__ObjectProperty]]"
+core__Property_domain: "[[cmd__Command]]"
+core__Property_range: "[[meta__Class]]"
+core__Asset_description: Тип сущности, которую создаёт/изменяет команда
 ---
 

--- a/03 Knowledge/application/commands/cmd__CompleteTask.md
+++ b/03 Knowledge/application/commands/cmd__CompleteTask.md
@@ -1,7 +1,7 @@
 ---
-exo__Asset_uid: d4e5f6a7-cmd0-0005-0000-000000000001
-exo__Asset_isDefinedBy: "[[!commands]]"
-exo__Instance_class:
+core__Asset_uid: d4e5f6a7-cmd0-0005-0000-000000000001
+core__Asset_isDefinedBy: "[[!commands]]"
+core__Instance_class:
   - "[[cmd__Command]]"
 cmd__Command_name: completeTask
 cmd__Command_description: Завершить задачу (установить endTimestamp)

--- a/03 Knowledge/application/commands/cmd__CreateTask.md
+++ b/03 Knowledge/application/commands/cmd__CreateTask.md
@@ -1,7 +1,7 @@
 ---
-exo__Asset_uid: d4e5f6a7-cmd0-0003-0000-000000000001
-exo__Asset_isDefinedBy: "[[!commands]]"
-exo__Instance_class:
+core__Asset_uid: d4e5f6a7-cmd0-0003-0000-000000000001
+core__Asset_isDefinedBy: "[[!commands]]"
+core__Instance_class:
   - "[[cmd__Command]]"
 cmd__Command_name: createTask
 cmd__Command_description: Создание новой задачи

--- a/03 Knowledge/application/commands/cmd__Search.md
+++ b/03 Knowledge/application/commands/cmd__Search.md
@@ -1,7 +1,7 @@
 ---
-exo__Asset_uid: d4e5f6a7-cmd0-0006-0000-000000000001
-exo__Asset_isDefinedBy: "[[!commands]]"
-exo__Instance_class:
+core__Asset_uid: d4e5f6a7-cmd0-0006-0000-000000000001
+core__Asset_isDefinedBy: "[[!commands]]"
+core__Instance_class:
   - "[[cmd__Command]]"
 cmd__Command_name: search
 cmd__Command_description: Универсальный поиск по базе знаний

--- a/03 Knowledge/application/commands/cmd__StartTask.md
+++ b/03 Knowledge/application/commands/cmd__StartTask.md
@@ -1,7 +1,7 @@
 ---
-exo__Asset_uid: d4e5f6a7-cmd0-0004-0000-000000000001
-exo__Asset_isDefinedBy: "[[!commands]]"
-exo__Instance_class:
+core__Asset_uid: d4e5f6a7-cmd0-0004-0000-000000000001
+core__Asset_isDefinedBy: "[[!commands]]"
+core__Instance_class:
   - "[[cmd__Command]]"
 cmd__Command_name: startTask
 cmd__Command_description: Начать выполнение задачи (установить startTimestamp)

--- a/03 Knowledge/application/forms/!forms.md
+++ b/03 Knowledge/application/forms/!forms.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_uid: d4e5f6a7-form-0001-0000-000000000001
-exo__Asset_label: Forms Ontology
-exo__Asset_description: Определение форм ввода данных для команд
-exo__Instance_class:
-  - "[[exo__Ontology]]"
+core__Asset_uid: d4e5f6a7-form-0001-0000-000000000001
+core__Asset_label: Forms Ontology
+core__Asset_description: Определение форм ввода данных для команд
+core__Instance_class:
+  - "[[core__Ontology]]"
 uri: https://exocortex.my/ontology/application/forms#
 prefix: form
 ---

--- a/03 Knowledge/application/forms/form__Form.md
+++ b/03 Knowledge/application/forms/form__Form.md
@@ -1,7 +1,7 @@
 ---
-exo__Asset_uid: d4e5f6a7-form-0002-0000-000000000001
-exo__Asset_isDefinedBy: "[[!forms]]"
-exo__Instance_class:
-  - "[[exo__Class]]"
-exo__Class_description: Форма ввода данных для команды
+core__Asset_uid: d4e5f6a7-form-0002-0000-000000000001
+core__Asset_isDefinedBy: "[[!forms]]"
+core__Instance_class:
+  - "[[core__Class]]"
+core__Class_description: Форма ввода данных для команды
 ---

--- a/03 Knowledge/application/forms/form__FormField.md
+++ b/03 Knowledge/application/forms/form__FormField.md
@@ -1,8 +1,8 @@
 ---
-exo__Asset_uid: d4e5f6a7-form-0003-0000-000000000001
-exo__Asset_isDefinedBy: "[[!forms]]"
-exo__Instance_class:
-  - "[[exo__Class]]"
-exo__Class_abstract: true
-exo__Class_description: Базовый класс поля формы
+core__Asset_uid: d4e5f6a7-form-0003-0000-000000000001
+core__Asset_isDefinedBy: "[[!forms]]"
+core__Instance_class:
+  - "[[core__Class]]"
+core__Class_abstract: true
+core__Class_description: Базовый класс поля формы
 ---

--- a/03 Knowledge/application/forms/form__FormField_label.md
+++ b/03 Knowledge/application/forms/form__FormField_label.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_isDefinedBy: "[[!forms]]"
-exo__Asset_uid: a1b2c3d4-4444-4000-8000-000000000010
-exo__Instance_class:
-  - "[[exo__StringProperty]]"
-exo__Property_domain: "[[form__FormField]]"
-exo__Asset_description: Отображаемый label поля
+core__Asset_isDefinedBy: "[[!forms]]"
+core__Asset_uid: a1b2c3d4-4444-4000-8000-000000000010
+core__Instance_class:
+  - "[[core__StringProperty]]"
+core__Property_domain: "[[form__FormField]]"
+core__Asset_description: Отображаемый label поля
 ---
 

--- a/03 Knowledge/application/forms/form__FormField_name.md
+++ b/03 Knowledge/application/forms/form__FormField_name.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_isDefinedBy: "[[!forms]]"
-exo__Asset_uid: a1b2c3d4-4444-4000-8000-000000000009
-exo__Instance_class:
-  - "[[exo__StringProperty]]"
-exo__Property_domain: "[[form__FormField]]"
-exo__Asset_description: Имя поля (используется для привязки к свойству)
+core__Asset_isDefinedBy: "[[!forms]]"
+core__Asset_uid: a1b2c3d4-4444-4000-8000-000000000009
+core__Instance_class:
+  - "[[core__StringProperty]]"
+core__Property_domain: "[[form__FormField]]"
+core__Asset_description: Имя поля (используется для привязки к свойству)
 ---
 

--- a/03 Knowledge/application/forms/form__FormField_property.md
+++ b/03 Knowledge/application/forms/form__FormField_property.md
@@ -1,10 +1,10 @@
 ---
-exo__Asset_isDefinedBy: "[[!forms]]"
-exo__Asset_uid: a1b2c3d4-4444-4000-8000-000000000013
-exo__Instance_class:
-  - "[[exo__ObjectProperty]]"
-exo__Property_domain: "[[form__FormField]]"
-exo__Property_range: "[[meta__Property]]"
-exo__Asset_description: Свойство онтологии, к которому привязано поле
+core__Asset_isDefinedBy: "[[!forms]]"
+core__Asset_uid: a1b2c3d4-4444-4000-8000-000000000013
+core__Instance_class:
+  - "[[core__ObjectProperty]]"
+core__Property_domain: "[[form__FormField]]"
+core__Property_range: "[[meta__Property]]"
+core__Asset_description: Свойство онтологии, к которому привязано поле
 ---
 

--- a/03 Knowledge/application/forms/form__FormField_required.md
+++ b/03 Knowledge/application/forms/form__FormField_required.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_isDefinedBy: "[[!forms]]"
-exo__Asset_uid: a1b2c3d4-4444-4000-8000-000000000012
-exo__Instance_class:
-  - "[[exo__BooleanProperty]]"
-exo__Property_domain: "[[form__FormField]]"
-exo__Asset_description: Обязательно ли заполнение поля
+core__Asset_isDefinedBy: "[[!forms]]"
+core__Asset_uid: a1b2c3d4-4444-4000-8000-000000000012
+core__Instance_class:
+  - "[[core__BooleanProperty]]"
+core__Property_domain: "[[form__FormField]]"
+core__Asset_description: Обязательно ли заполнение поля
 ---
 

--- a/03 Knowledge/application/forms/form__FormField_type.md
+++ b/03 Knowledge/application/forms/form__FormField_type.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_isDefinedBy: "[[!forms]]"
-exo__Asset_uid: a1b2c3d4-4444-4000-8000-000000000011
-exo__Instance_class:
-  - "[[exo__StringProperty]]"
-exo__Property_domain: "[[form__FormField]]"
-exo__Asset_description: Тип поля (text, number, date, link, select, etc.)
+core__Asset_isDefinedBy: "[[!forms]]"
+core__Asset_uid: a1b2c3d4-4444-4000-8000-000000000011
+core__Instance_class:
+  - "[[core__StringProperty]]"
+core__Property_domain: "[[form__FormField]]"
+core__Asset_description: Тип поля (text, number, date, link, select, etc.)
 ---
 

--- a/03 Knowledge/application/forms/form__Form_fields.md
+++ b/03 Knowledge/application/forms/form__Form_fields.md
@@ -1,10 +1,10 @@
 ---
-exo__Asset_isDefinedBy: "[[!forms]]"
-exo__Asset_uid: a1b2c3d4-4444-4000-8000-000000000008
-exo__Instance_class:
-  - "[[exo__ObjectProperty]]"
-exo__Property_domain: "[[form__Form]]"
-exo__Property_range: "[[form__FormField]]"
-exo__Asset_description: Поля формы (упорядоченный список)
+core__Asset_isDefinedBy: "[[!forms]]"
+core__Asset_uid: a1b2c3d4-4444-4000-8000-000000000008
+core__Instance_class:
+  - "[[core__ObjectProperty]]"
+core__Property_domain: "[[form__Form]]"
+core__Property_range: "[[form__FormField]]"
+core__Asset_description: Поля формы (упорядоченный список)
 ---
 

--- a/03 Knowledge/application/forms/form__LinkField.md
+++ b/03 Knowledge/application/forms/form__LinkField.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_uid: d4e5f6a7-form-0004-0000-000000000001
-exo__Asset_isDefinedBy: "[[!forms]]"
-exo__Instance_class:
-  - "[[exo__Class]]"
-exo__Class_superClass:
+core__Asset_uid: d4e5f6a7-form-0004-0000-000000000001
+core__Asset_isDefinedBy: "[[!forms]]"
+core__Instance_class:
+  - "[[core__Class]]"
+core__Class_superClass:
   - "[[form__FormField]]"
-exo__Class_description: Поле для выбора ссылки на Asset определённого типа
+core__Class_description: Поле для выбора ссылки на Asset определённого типа
 ---

--- a/03 Knowledge/application/forms/form__LinkField_targetType.md
+++ b/03 Knowledge/application/forms/form__LinkField_targetType.md
@@ -1,10 +1,10 @@
 ---
-exo__Asset_isDefinedBy: "[[!forms]]"
-exo__Asset_uid: a1b2c3d4-4444-4000-8000-000000000014
-exo__Instance_class:
-  - "[[exo__ObjectProperty]]"
-exo__Property_domain: "[[form__LinkField]]"
-exo__Property_range: "[[meta__Class]]"
-exo__Asset_description: Тип целевых сущностей для выбора
+core__Asset_isDefinedBy: "[[!forms]]"
+core__Asset_uid: a1b2c3d4-4444-4000-8000-000000000014
+core__Instance_class:
+  - "[[core__ObjectProperty]]"
+core__Property_domain: "[[form__LinkField]]"
+core__Property_range: "[[meta__Class]]"
+core__Asset_description: Тип целевых сущностей для выбора
 ---
 

--- a/03 Knowledge/core/!core.md
+++ b/03 Knowledge/core/!core.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_uid: a1b2c3d4-core-0001-0000-000000000001
-exo__Asset_label: Core Ontology
-exo__Asset_description: Shared Kernel - базовые абстракции системы
-exo__Instance_class:
-  - "[[exo__Ontology]]"
+core__Asset_uid: a1b2c3d4-core-0001-0000-000000000001
+core__Asset_label: Core Ontology
+core__Asset_description: Shared Kernel - базовые абстракции системы
+core__Instance_class:
+  - "[[core__Ontology]]"
 uri: https://exocortex.my/ontology/core#
 prefix: core
 ---

--- a/03 Knowledge/core/core__Asset.md
+++ b/03 Knowledge/core/core__Asset.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_uid: a1b2c3d4-core-0002-0000-000000000001
-exo__Asset_isDefinedBy: "[[!core]]"
-exo__Instance_class:
-  - "[[exo__Class]]"
-exo__Class_superClass:
-  - "[[exo__Resource]]"
-exo__Class_description: Базовая единица знаний в системе Exocortex
+core__Asset_uid: a1b2c3d4-core-0002-0000-000000000001
+core__Asset_isDefinedBy: "[[!core]]"
+core__Instance_class:
+  - "[[core__Class]]"
+core__Class_superClass:
+  - "[[core__Resource]]"
+core__Class_description: Базовая единица знаний в системе Exocortex
 ---

--- a/03 Knowledge/core/core__Asset_created.md
+++ b/03 Knowledge/core/core__Asset_created.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_isDefinedBy: "[[!core]]"
-exo__Asset_uid: a1b2c3d4-1111-4000-8000-000000000002
-exo__Instance_class:
-  - "[[exo__DateTimeProperty]]"
-exo__Property_domain: "[[core__Asset]]"
-exo__Asset_description: Дата и время создания ассета
+core__Asset_isDefinedBy: "[[!core]]"
+core__Asset_uid: a1b2c3d4-1111-4000-8000-000000000002
+core__Instance_class:
+  - "[[core__DateTimeProperty]]"
+core__Property_domain: "[[core__Asset]]"
+core__Asset_description: Дата и время создания ассета
 ---
 

--- a/03 Knowledge/core/core__Asset_description.md
+++ b/03 Knowledge/core/core__Asset_description.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_isDefinedBy: "[[!core]]"
-exo__Asset_uid: a1b2c3d4-1111-4000-8000-000000000005
-exo__Instance_class:
-  - "[[exo__StringProperty]]"
-exo__Property_domain: "[[core__Asset]]"
-exo__Asset_description: Описание ассета
+core__Asset_isDefinedBy: "[[!core]]"
+core__Asset_uid: a1b2c3d4-1111-4000-8000-000000000005
+core__Instance_class:
+  - "[[core__StringProperty]]"
+core__Property_domain: "[[core__Asset]]"
+core__Asset_description: Описание ассета
 ---
 

--- a/03 Knowledge/core/core__Asset_label.md
+++ b/03 Knowledge/core/core__Asset_label.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_isDefinedBy: "[[!core]]"
-exo__Asset_uid: a1b2c3d4-1111-4000-8000-000000000001
-exo__Instance_class:
-  - "[[exo__StringProperty]]"
-exo__Property_domain: "[[core__Asset]]"
-exo__Asset_description: Человекочитаемое название ассета
+core__Asset_isDefinedBy: "[[!core]]"
+core__Asset_uid: a1b2c3d4-1111-4000-8000-000000000001
+core__Instance_class:
+  - "[[core__StringProperty]]"
+core__Property_domain: "[[core__Asset]]"
+core__Asset_description: Человекочитаемое название ассета
 ---
 

--- a/03 Knowledge/core/core__Asset_modified.md
+++ b/03 Knowledge/core/core__Asset_modified.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_isDefinedBy: "[[!core]]"
-exo__Asset_uid: a1b2c3d4-1111-4000-8000-000000000003
-exo__Instance_class:
-  - "[[exo__DateTimeProperty]]"
-exo__Property_domain: "[[core__Asset]]"
-exo__Asset_description: Дата и время последнего изменения ассета
+core__Asset_isDefinedBy: "[[!core]]"
+core__Asset_uid: a1b2c3d4-1111-4000-8000-000000000003
+core__Instance_class:
+  - "[[core__DateTimeProperty]]"
+core__Property_domain: "[[core__Asset]]"
+core__Asset_description: Дата и время последнего изменения ассета
 ---
 

--- a/03 Knowledge/core/core__Asset_uri.md
+++ b/03 Knowledge/core/core__Asset_uri.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_isDefinedBy: "[[!core]]"
-exo__Asset_uid: a1b2c3d4-1111-4000-8000-000000000004
-exo__Instance_class:
-  - "[[exo__StringProperty]]"
-exo__Property_domain: "[[core__Asset]]"
-exo__Asset_description: Уникальный идентификатор (URI) ассета
+core__Asset_isDefinedBy: "[[!core]]"
+core__Asset_uid: a1b2c3d4-1111-4000-8000-000000000004
+core__Instance_class:
+  - "[[core__StringProperty]]"
+core__Property_domain: "[[core__Asset]]"
+core__Asset_description: Уникальный идентификатор (URI) ассета
 ---
 

--- a/03 Knowledge/core/core__BooleanProperty.md
+++ b/03 Knowledge/core/core__BooleanProperty.md
@@ -1,0 +1,9 @@
+---
+core__Asset_uid: a1b2c3d4-core-0001-0000-000000000008
+core__Asset_isDefinedBy: "[[!core]]"
+core__Instance_class:
+  - "[[core__Class]]"
+core__Class_superClass:
+  - "[[core__DatatypeProperty]]"
+core__Class_description: Свойство с булевым значением
+---

--- a/03 Knowledge/core/core__Class.md
+++ b/03 Knowledge/core/core__Class.md
@@ -1,0 +1,9 @@
+---
+core__Asset_uid: a1b2c3d4-core-0001-0000-000000000002
+core__Asset_isDefinedBy: "[[!core]]"
+core__Instance_class:
+  - "[[core__Class]]"
+core__Class_superClass:
+  - "[[core__Resource]]"
+core__Class_description: Метакласс - класс всех классов
+---

--- a/03 Knowledge/core/core__DatatypeProperty.md
+++ b/03 Knowledge/core/core__DatatypeProperty.md
@@ -1,0 +1,9 @@
+---
+core__Asset_uid: a1b2c3d4-core-0001-0000-000000000005
+core__Asset_isDefinedBy: "[[!core]]"
+core__Instance_class:
+  - "[[core__Class]]"
+core__Class_superClass:
+  - "[[core__Property]]"
+core__Class_description: Свойство со значением примитивного типа
+---

--- a/03 Knowledge/core/core__DateProperty.md
+++ b/03 Knowledge/core/core__DateProperty.md
@@ -1,0 +1,9 @@
+---
+core__Asset_uid: a1b2c3d4-core-0001-0000-000000000009
+core__Asset_isDefinedBy: "[[!core]]"
+core__Instance_class:
+  - "[[core__Class]]"
+core__Class_superClass:
+  - "[[core__DatatypeProperty]]"
+core__Class_description: Свойство с датой (без времени)
+---

--- a/03 Knowledge/core/core__DateTimeProperty.md
+++ b/03 Knowledge/core/core__DateTimeProperty.md
@@ -1,0 +1,9 @@
+---
+core__Asset_uid: a1b2c3d4-core-0001-0000-000000000010
+core__Asset_isDefinedBy: "[[!core]]"
+core__Instance_class:
+  - "[[core__Class]]"
+core__Class_superClass:
+  - "[[core__DatatypeProperty]]"
+core__Class_description: Свойство с датой и временем (ISO 8601)
+---

--- a/03 Knowledge/core/core__NumberProperty.md
+++ b/03 Knowledge/core/core__NumberProperty.md
@@ -1,0 +1,9 @@
+---
+core__Asset_uid: a1b2c3d4-core-0001-0000-000000000007
+core__Asset_isDefinedBy: "[[!core]]"
+core__Instance_class:
+  - "[[core__Class]]"
+core__Class_superClass:
+  - "[[core__DatatypeProperty]]"
+core__Class_description: Свойство с числовым значением
+---

--- a/03 Knowledge/core/core__ObjectProperty.md
+++ b/03 Knowledge/core/core__ObjectProperty.md
@@ -1,0 +1,9 @@
+---
+core__Asset_uid: a1b2c3d4-core-0001-0000-000000000004
+core__Asset_isDefinedBy: "[[!core]]"
+core__Instance_class:
+  - "[[core__Class]]"
+core__Class_superClass:
+  - "[[core__Property]]"
+core__Class_description: Свойство, связывающее два ресурса (ссылка на другой Asset)
+---

--- a/03 Knowledge/core/core__Ontology.md
+++ b/03 Knowledge/core/core__Ontology.md
@@ -1,0 +1,9 @@
+---
+core__Asset_uid: a1b2c3d4-core-0001-0000-000000000011
+core__Asset_isDefinedBy: "[[!core]]"
+core__Instance_class:
+  - "[[core__Class]]"
+core__Class_superClass:
+  - "[[core__Asset]]"
+core__Class_description: Онтология - набор связанных классов и свойств
+---

--- a/03 Knowledge/core/core__Property.md
+++ b/03 Knowledge/core/core__Property.md
@@ -1,0 +1,9 @@
+---
+core__Asset_uid: a1b2c3d4-core-0001-0000-000000000003
+core__Asset_isDefinedBy: "[[!core]]"
+core__Instance_class:
+  - "[[core__Class]]"
+core__Class_superClass:
+  - "[[core__Resource]]"
+core__Class_description: Базовый класс для всех свойств
+---

--- a/03 Knowledge/core/core__Reference.md
+++ b/03 Knowledge/core/core__Reference.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_uid: a1b2c3d4-core-0003-0000-000000000001
-exo__Asset_isDefinedBy: "[[!core]]"
-exo__Instance_class:
-  - "[[exo__Class]]"
-exo__Class_superClass:
+core__Asset_uid: a1b2c3d4-core-0003-0000-000000000001
+core__Asset_isDefinedBy: "[[!core]]"
+core__Instance_class:
+  - "[[core__Class]]"
+core__Class_superClass:
   - "[[core__Asset]]"
-exo__Class_description: Ссылка на другой Asset
+core__Class_description: Ссылка на другой Asset
 ---

--- a/03 Knowledge/core/core__Reference_target.md
+++ b/03 Knowledge/core/core__Reference_target.md
@@ -1,10 +1,10 @@
 ---
-exo__Asset_isDefinedBy: "[[!core]]"
-exo__Asset_uid: a1b2c3d4-1111-4000-8000-000000000006
-exo__Instance_class:
-  - "[[exo__ObjectProperty]]"
-exo__Property_domain: "[[core__Reference]]"
-exo__Property_range: "[[core__Asset]]"
-exo__Asset_description: Целевой ассет, на который указывает ссылка
+core__Asset_isDefinedBy: "[[!core]]"
+core__Asset_uid: a1b2c3d4-1111-4000-8000-000000000006
+core__Instance_class:
+  - "[[core__ObjectProperty]]"
+core__Property_domain: "[[core__Reference]]"
+core__Property_range: "[[core__Asset]]"
+core__Asset_description: Целевой ассет, на который указывает ссылка
 ---
 

--- a/03 Knowledge/core/core__Relation.md
+++ b/03 Knowledge/core/core__Relation.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_uid: a1b2c3d4-core-0004-0000-000000000001
-exo__Asset_isDefinedBy: "[[!core]]"
-exo__Instance_class:
-  - "[[exo__Class]]"
-exo__Class_superClass:
+core__Asset_uid: a1b2c3d4-core-0004-0000-000000000001
+core__Asset_isDefinedBy: "[[!core]]"
+core__Instance_class:
+  - "[[core__Class]]"
+core__Class_superClass:
   - "[[owl__ObjectProperty]]"
-exo__Class_description: Типизированная связь между Assets
+core__Class_description: Типизированная связь между Assets
 ---

--- a/03 Knowledge/core/core__Relation_source.md
+++ b/03 Knowledge/core/core__Relation_source.md
@@ -1,10 +1,10 @@
 ---
-exo__Asset_isDefinedBy: "[[!core]]"
-exo__Asset_uid: a1b2c3d4-1111-4000-8000-000000000007
-exo__Instance_class:
-  - "[[exo__ObjectProperty]]"
-exo__Property_domain: "[[core__Relation]]"
-exo__Property_range: "[[core__Asset]]"
-exo__Asset_description: Исходный ассет в связи
+core__Asset_isDefinedBy: "[[!core]]"
+core__Asset_uid: a1b2c3d4-1111-4000-8000-000000000007
+core__Instance_class:
+  - "[[core__ObjectProperty]]"
+core__Property_domain: "[[core__Relation]]"
+core__Property_range: "[[core__Asset]]"
+core__Asset_description: Исходный ассет в связи
 ---
 

--- a/03 Knowledge/core/core__Relation_target.md
+++ b/03 Knowledge/core/core__Relation_target.md
@@ -1,10 +1,10 @@
 ---
-exo__Asset_isDefinedBy: "[[!core]]"
-exo__Asset_uid: a1b2c3d4-1111-4000-8000-000000000008
-exo__Instance_class:
-  - "[[exo__ObjectProperty]]"
-exo__Property_domain: "[[core__Relation]]"
-exo__Property_range: "[[core__Asset]]"
-exo__Asset_description: Целевой ассет в связи
+core__Asset_isDefinedBy: "[[!core]]"
+core__Asset_uid: a1b2c3d4-1111-4000-8000-000000000008
+core__Instance_class:
+  - "[[core__ObjectProperty]]"
+core__Property_domain: "[[core__Relation]]"
+core__Property_range: "[[core__Asset]]"
+core__Asset_description: Целевой ассет в связи
 ---
 

--- a/03 Knowledge/core/core__Relation_type.md
+++ b/03 Knowledge/core/core__Relation_type.md
@@ -1,10 +1,10 @@
 ---
-exo__Asset_isDefinedBy: "[[!core]]"
-exo__Asset_uid: a1b2c3d4-1111-4000-8000-000000000009
-exo__Instance_class:
-  - "[[exo__ObjectProperty]]"
-exo__Property_domain: "[[core__Relation]]"
-exo__Property_range: "[[exo__Property]]"
-exo__Asset_description: Тип связи (property, определяющий семантику)
+core__Asset_isDefinedBy: "[[!core]]"
+core__Asset_uid: a1b2c3d4-1111-4000-8000-000000000009
+core__Instance_class:
+  - "[[core__ObjectProperty]]"
+core__Property_domain: "[[core__Relation]]"
+core__Property_range: "[[core__Property]]"
+core__Asset_description: Тип связи (property, определяющий семантику)
 ---
 

--- a/03 Knowledge/core/core__Resource.md
+++ b/03 Knowledge/core/core__Resource.md
@@ -1,0 +1,7 @@
+---
+core__Asset_uid: a1b2c3d4-core-0001-0000-000000000001
+core__Asset_isDefinedBy: "[[!core]]"
+core__Instance_class:
+  - "[[core__Class]]"
+core__Class_description: Базовый ресурс - корень иерархии всех типов
+---

--- a/03 Knowledge/core/core__StringProperty.md
+++ b/03 Knowledge/core/core__StringProperty.md
@@ -1,0 +1,9 @@
+---
+core__Asset_uid: a1b2c3d4-core-0001-0000-000000000006
+core__Asset_isDefinedBy: "[[!core]]"
+core__Instance_class:
+  - "[[core__Class]]"
+core__Class_superClass:
+  - "[[core__DatatypeProperty]]"
+core__Class_description: Свойство со строковым значением
+---

--- a/03 Knowledge/domain/ems/!ems.md
+++ b/03 Knowledge/domain/ems/!ems.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_uid: c3d4e5f6-ems0-0001-0000-000000000001
-exo__Asset_label: EMS Domain Ontology
-exo__Asset_description: Effort Management System - управление задачами, проектами и областями
-exo__Instance_class:
-  - "[[exo__Ontology]]"
+core__Asset_uid: c3d4e5f6-ems0-0001-0000-000000000001
+core__Asset_label: EMS Domain Ontology
+core__Asset_description: Effort Management System - управление задачами, проектами и областями
+core__Instance_class:
+  - "[[core__Ontology]]"
 uri: https://exocortex.my/ontology/domain/ems#
 prefix: ems
 ---

--- a/03 Knowledge/domain/ems/ems__Area.md
+++ b/03 Knowledge/domain/ems/ems__Area.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_uid: c3d4e5f6-ems0-0004-0000-000000000001
-exo__Asset_isDefinedBy: "[[!ems]]"
-exo__Instance_class:
-  - "[[exo__Class]]"
-exo__Class_superClass:
+core__Asset_uid: c3d4e5f6-ems0-0004-0000-000000000001
+core__Asset_isDefinedBy: "[[!ems]]"
+core__Instance_class:
+  - "[[core__Class]]"
+core__Class_superClass:
   - "[[core__Asset]]"
-exo__Class_description: Область ответственности - бессрочная категория для задач и проектов
+core__Class_description: Область ответственности - бессрочная категория для задач и проектов
 ---

--- a/03 Knowledge/domain/ems/ems__Area_parent.md
+++ b/03 Knowledge/domain/ems/ems__Area_parent.md
@@ -1,10 +1,10 @@
 ---
-exo__Asset_isDefinedBy: "[[!ems]]"
-exo__Asset_uid: a1b2c3d4-3333-4000-8000-000000000009
-exo__Instance_class:
-  - "[[exo__ObjectProperty]]"
-exo__Property_domain: "[[ems__Area]]"
-exo__Property_range: "[[ems__Area]]"
-exo__Asset_description: Родительская область (для иерархии областей)
+core__Asset_isDefinedBy: "[[!ems]]"
+core__Asset_uid: a1b2c3d4-3333-4000-8000-000000000009
+core__Instance_class:
+  - "[[core__ObjectProperty]]"
+core__Property_domain: "[[ems__Area]]"
+core__Property_range: "[[ems__Area]]"
+core__Asset_description: Родительская область (для иерархии областей)
 ---
 

--- a/03 Knowledge/domain/ems/ems__Effort.md
+++ b/03 Knowledge/domain/ems/ems__Effort.md
@@ -1,8 +1,8 @@
 ---
-exo__Asset_uid: c3d4e5f6-ems0-0006-0000-000000000001
-exo__Asset_isDefinedBy: "[[!ems]]"
-exo__Instance_class:
-  - "[[exo__Class]]"
-exo__Class_abstract: true
-exo__Class_description: Mixin для трекинга времени выполнения (startTimestamp, endTimestamp)
+core__Asset_uid: c3d4e5f6-ems0-0006-0000-000000000001
+core__Asset_isDefinedBy: "[[!ems]]"
+core__Instance_class:
+  - "[[core__Class]]"
+core__Class_abstract: true
+core__Class_description: Mixin для трекинга времени выполнения (startTimestamp, endTimestamp)
 ---

--- a/03 Knowledge/domain/ems/ems__Effort_endTimestamp.md
+++ b/03 Knowledge/domain/ems/ems__Effort_endTimestamp.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_isDefinedBy: "[[!ems]]"
-exo__Asset_uid: a1b2c3d4-3333-4000-8000-000000000011
-exo__Instance_class:
-  - "[[exo__DateTimeProperty]]"
-exo__Property_domain: "[[ems__Effort]]"
-exo__Asset_description: Время завершения усилия (работы над задачей)
+core__Asset_isDefinedBy: "[[!ems]]"
+core__Asset_uid: a1b2c3d4-3333-4000-8000-000000000011
+core__Instance_class:
+  - "[[core__DateTimeProperty]]"
+core__Property_domain: "[[ems__Effort]]"
+core__Asset_description: Время завершения усилия (работы над задачей)
 ---
 

--- a/03 Knowledge/domain/ems/ems__Effort_startTimestamp.md
+++ b/03 Knowledge/domain/ems/ems__Effort_startTimestamp.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_isDefinedBy: "[[!ems]]"
-exo__Asset_uid: a1b2c3d4-3333-4000-8000-000000000010
-exo__Instance_class:
-  - "[[exo__DateTimeProperty]]"
-exo__Property_domain: "[[ems__Effort]]"
-exo__Asset_description: Время начала усилия (работы над задачей)
+core__Asset_isDefinedBy: "[[!ems]]"
+core__Asset_uid: a1b2c3d4-3333-4000-8000-000000000010
+core__Instance_class:
+  - "[[core__DateTimeProperty]]"
+core__Property_domain: "[[ems__Effort]]"
+core__Asset_description: Время начала усилия (работы над задачей)
 ---
 

--- a/03 Knowledge/domain/ems/ems__Project.md
+++ b/03 Knowledge/domain/ems/ems__Project.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_uid: c3d4e5f6-ems0-0003-0000-000000000001
-exo__Asset_isDefinedBy: "[[!ems]]"
-exo__Instance_class:
-  - "[[exo__Class]]"
-exo__Class_superClass:
+core__Asset_uid: c3d4e5f6-ems0-0003-0000-000000000001
+core__Asset_isDefinedBy: "[[!ems]]"
+core__Instance_class:
+  - "[[core__Class]]"
+core__Class_superClass:
   - "[[core__Asset]]"
-exo__Class_description: Проект - контейнер для связанных задач с общей целью
+core__Class_description: Проект - контейнер для связанных задач с общей целью
 ---

--- a/03 Knowledge/domain/ems/ems__Project_area.md
+++ b/03 Knowledge/domain/ems/ems__Project_area.md
@@ -1,10 +1,10 @@
 ---
-exo__Asset_isDefinedBy: "[[!ems]]"
-exo__Asset_uid: a1b2c3d4-3333-4000-8000-000000000006
-exo__Instance_class:
-  - "[[exo__ObjectProperty]]"
-exo__Property_domain: "[[ems__Project]]"
-exo__Property_range: "[[ems__Area]]"
-exo__Asset_description: Область ответственности, к которой относится проект
+core__Asset_isDefinedBy: "[[!ems]]"
+core__Asset_uid: a1b2c3d4-3333-4000-8000-000000000006
+core__Instance_class:
+  - "[[core__ObjectProperty]]"
+core__Property_domain: "[[ems__Project]]"
+core__Property_range: "[[ems__Area]]"
+core__Asset_description: Область ответственности, к которой относится проект
 ---
 

--- a/03 Knowledge/domain/ems/ems__Project_dueDate.md
+++ b/03 Knowledge/domain/ems/ems__Project_dueDate.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_isDefinedBy: "[[!ems]]"
-exo__Asset_uid: a1b2c3d4-3333-4000-8000-000000000008
-exo__Instance_class:
-  - "[[exo__DateProperty]]"
-exo__Property_domain: "[[ems__Project]]"
-exo__Asset_description: Срок завершения проекта
+core__Asset_isDefinedBy: "[[!ems]]"
+core__Asset_uid: a1b2c3d4-3333-4000-8000-000000000008
+core__Instance_class:
+  - "[[core__DateProperty]]"
+core__Property_domain: "[[ems__Project]]"
+core__Asset_description: Срок завершения проекта
 ---
 

--- a/03 Knowledge/domain/ems/ems__Project_status.md
+++ b/03 Knowledge/domain/ems/ems__Project_status.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_isDefinedBy: "[[!ems]]"
-exo__Asset_uid: a1b2c3d4-3333-4000-8000-000000000007
-exo__Instance_class:
-  - "[[exo__StringProperty]]"
-exo__Property_domain: "[[ems__Project]]"
-exo__Asset_description: Статус проекта (active, paused, completed, archived)
+core__Asset_isDefinedBy: "[[!ems]]"
+core__Asset_uid: a1b2c3d4-3333-4000-8000-000000000007
+core__Instance_class:
+  - "[[core__StringProperty]]"
+core__Property_domain: "[[ems__Project]]"
+core__Asset_description: Статус проекта (active, paused, completed, archived)
 ---
 

--- a/03 Knowledge/domain/ems/ems__Prototype.md
+++ b/03 Knowledge/domain/ems/ems__Prototype.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_uid: c3d4e5f6-ems0-0005-0000-000000000001
-exo__Asset_isDefinedBy: "[[!ems]]"
-exo__Instance_class:
-  - "[[exo__Class]]"
-exo__Class_superClass:
+core__Asset_uid: c3d4e5f6-ems0-0005-0000-000000000001
+core__Asset_isDefinedBy: "[[!ems]]"
+core__Instance_class:
+  - "[[core__Class]]"
+core__Class_superClass:
   - "[[core__Asset]]"
-exo__Class_description: Прототип - шаблон для создания однотипных задач
+core__Class_description: Прототип - шаблон для создания однотипных задач
 ---

--- a/03 Knowledge/domain/ems/ems__Prototype_area.md
+++ b/03 Knowledge/domain/ems/ems__Prototype_area.md
@@ -1,10 +1,10 @@
 ---
-exo__Asset_isDefinedBy: "[[!ems]]"
-exo__Asset_uid: a1b2c3d4-3333-4000-8000-000000000013
-exo__Instance_class:
-  - "[[exo__ObjectProperty]]"
-exo__Property_domain: "[[ems__Prototype]]"
-exo__Property_range: "[[ems__Area]]"
-exo__Asset_description: Область по умолчанию для задач этого прототипа
+core__Asset_isDefinedBy: "[[!ems]]"
+core__Asset_uid: a1b2c3d4-3333-4000-8000-000000000013
+core__Instance_class:
+  - "[[core__ObjectProperty]]"
+core__Property_domain: "[[ems__Prototype]]"
+core__Property_range: "[[ems__Area]]"
+core__Asset_description: Область по умолчанию для задач этого прототипа
 ---
 

--- a/03 Knowledge/domain/ems/ems__Prototype_defaultDuration.md
+++ b/03 Knowledge/domain/ems/ems__Prototype_defaultDuration.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_isDefinedBy: "[[!ems]]"
-exo__Asset_uid: a1b2c3d4-3333-4000-8000-000000000012
-exo__Instance_class:
-  - "[[exo__NumberProperty]]"
-exo__Property_domain: "[[ems__Prototype]]"
-exo__Asset_description: Предполагаемая длительность задачи в минутах
+core__Asset_isDefinedBy: "[[!ems]]"
+core__Asset_uid: a1b2c3d4-3333-4000-8000-000000000012
+core__Instance_class:
+  - "[[core__NumberProperty]]"
+core__Property_domain: "[[ems__Prototype]]"
+core__Asset_description: Предполагаемая длительность задачи в минутах
 ---
 

--- a/03 Knowledge/domain/ems/ems__Task.md
+++ b/03 Knowledge/domain/ems/ems__Task.md
@@ -1,10 +1,10 @@
 ---
-exo__Asset_uid: c3d4e5f6-ems0-0002-0000-000000000001
-exo__Asset_isDefinedBy: "[[!ems]]"
-exo__Instance_class:
-  - "[[exo__Class]]"
-exo__Class_superClass:
+core__Asset_uid: c3d4e5f6-ems0-0002-0000-000000000001
+core__Asset_isDefinedBy: "[[!ems]]"
+core__Instance_class:
+  - "[[core__Class]]"
+core__Class_superClass:
   - "[[core__Asset]]"
   - "[[ems__Effort]]"
-exo__Class_description: Задача - единица работы с временными рамками
+core__Class_description: Задача - единица работы с временными рамками
 ---

--- a/03 Knowledge/domain/ems/ems__Task_area.md
+++ b/03 Knowledge/domain/ems/ems__Task_area.md
@@ -1,10 +1,10 @@
 ---
-exo__Asset_isDefinedBy: "[[!ems]]"
-exo__Asset_uid: a1b2c3d4-3333-4000-8000-000000000002
-exo__Instance_class:
-  - "[[exo__ObjectProperty]]"
-exo__Property_domain: "[[ems__Task]]"
-exo__Property_range: "[[ems__Area]]"
-exo__Asset_description: Область ответственности, к которой относится задача
+core__Asset_isDefinedBy: "[[!ems]]"
+core__Asset_uid: a1b2c3d4-3333-4000-8000-000000000002
+core__Instance_class:
+  - "[[core__ObjectProperty]]"
+core__Property_domain: "[[ems__Task]]"
+core__Property_range: "[[ems__Area]]"
+core__Asset_description: Область ответственности, к которой относится задача
 ---
 

--- a/03 Knowledge/domain/ems/ems__Task_dueDate.md
+++ b/03 Knowledge/domain/ems/ems__Task_dueDate.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_isDefinedBy: "[[!ems]]"
-exo__Asset_uid: a1b2c3d4-3333-4000-8000-000000000005
-exo__Instance_class:
-  - "[[exo__DateProperty]]"
-exo__Property_domain: "[[ems__Task]]"
-exo__Asset_description: Срок выполнения задачи
+core__Asset_isDefinedBy: "[[!ems]]"
+core__Asset_uid: a1b2c3d4-3333-4000-8000-000000000005
+core__Instance_class:
+  - "[[core__DateProperty]]"
+core__Property_domain: "[[ems__Task]]"
+core__Asset_description: Срок выполнения задачи
 ---
 

--- a/03 Knowledge/domain/ems/ems__Task_priority.md
+++ b/03 Knowledge/domain/ems/ems__Task_priority.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_isDefinedBy: "[[!ems]]"
-exo__Asset_uid: a1b2c3d4-3333-4000-8000-000000000004
-exo__Instance_class:
-  - "[[exo__NumberProperty]]"
-exo__Property_domain: "[[ems__Task]]"
-exo__Asset_description: Приоритет задачи (1-5, где 1 = наивысший)
+core__Asset_isDefinedBy: "[[!ems]]"
+core__Asset_uid: a1b2c3d4-3333-4000-8000-000000000004
+core__Instance_class:
+  - "[[core__NumberProperty]]"
+core__Property_domain: "[[ems__Task]]"
+core__Asset_description: Приоритет задачи (1-5, где 1 = наивысший)
 ---
 

--- a/03 Knowledge/domain/ems/ems__Task_project.md
+++ b/03 Knowledge/domain/ems/ems__Task_project.md
@@ -1,10 +1,10 @@
 ---
-exo__Asset_isDefinedBy: "[[!ems]]"
-exo__Asset_uid: a1b2c3d4-3333-4000-8000-000000000001
-exo__Instance_class:
-  - "[[exo__ObjectProperty]]"
-exo__Property_domain: "[[ems__Task]]"
-exo__Property_range: "[[ems__Project]]"
-exo__Asset_description: Проект, к которому относится задача
+core__Asset_isDefinedBy: "[[!ems]]"
+core__Asset_uid: a1b2c3d4-3333-4000-8000-000000000001
+core__Instance_class:
+  - "[[core__ObjectProperty]]"
+core__Property_domain: "[[ems__Task]]"
+core__Property_range: "[[ems__Project]]"
+core__Asset_description: Проект, к которому относится задача
 ---
 

--- a/03 Knowledge/domain/ems/ems__Task_prototype.md
+++ b/03 Knowledge/domain/ems/ems__Task_prototype.md
@@ -1,10 +1,10 @@
 ---
-exo__Asset_isDefinedBy: "[[!ems]]"
-exo__Asset_uid: a1b2c3d4-3333-4000-8000-000000000003
-exo__Instance_class:
-  - "[[exo__ObjectProperty]]"
-exo__Property_domain: "[[ems__Task]]"
-exo__Property_range: "[[ems__Prototype]]"
-exo__Asset_description: Прототип (шаблон) задачи
+core__Asset_isDefinedBy: "[[!ems]]"
+core__Asset_uid: a1b2c3d4-3333-4000-8000-000000000003
+core__Instance_class:
+  - "[[core__ObjectProperty]]"
+core__Property_domain: "[[ems__Task]]"
+core__Property_range: "[[ems__Prototype]]"
+core__Asset_description: Прототип (шаблон) задачи
 ---
 

--- a/03 Knowledge/meta/!meta.md
+++ b/03 Knowledge/meta/!meta.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_uid: b2c3d4e5-meta-0001-0000-000000000001
-exo__Asset_label: Meta Ontology
-exo__Asset_description: Мета-моделирование - определение классов, свойств и ограничений
-exo__Instance_class:
-  - "[[exo__Ontology]]"
+core__Asset_uid: b2c3d4e5-meta-0001-0000-000000000001
+core__Asset_label: Meta Ontology
+core__Asset_description: Мета-моделирование - определение классов, свойств и ограничений
+core__Instance_class:
+  - "[[core__Ontology]]"
 uri: https://exocortex.my/ontology/meta#
 prefix: meta
 ---

--- a/03 Knowledge/meta/meta__Cardinality.md
+++ b/03 Knowledge/meta/meta__Cardinality.md
@@ -1,7 +1,7 @@
 ---
-exo__Asset_uid: b2c3d4e5-meta-0005-0000-000000000001
-exo__Asset_isDefinedBy: "[[!meta]]"
-exo__Instance_class:
-  - "[[exo__Class]]"
-exo__Class_description: Кардинальность свойства (сколько значений допустимо)
+core__Asset_uid: b2c3d4e5-meta-0005-0000-000000000001
+core__Asset_isDefinedBy: "[[!meta]]"
+core__Instance_class:
+  - "[[core__Class]]"
+core__Class_description: Кардинальность свойства (сколько значений допустимо)
 ---

--- a/03 Knowledge/meta/meta__Cardinality_max.md
+++ b/03 Knowledge/meta/meta__Cardinality_max.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_isDefinedBy: "[[!meta]]"
-exo__Asset_uid: a1b2c3d4-2222-4000-8000-000000000009
-exo__Instance_class:
-  - "[[exo__NumberProperty]]"
-exo__Property_domain: "[[meta__Cardinality]]"
-exo__Asset_description: Максимальное количество значений свойства (null = unbounded)
+core__Asset_isDefinedBy: "[[!meta]]"
+core__Asset_uid: a1b2c3d4-2222-4000-8000-000000000009
+core__Instance_class:
+  - "[[core__NumberProperty]]"
+core__Property_domain: "[[meta__Cardinality]]"
+core__Asset_description: Максимальное количество значений свойства (null = unbounded)
 ---
 

--- a/03 Knowledge/meta/meta__Cardinality_min.md
+++ b/03 Knowledge/meta/meta__Cardinality_min.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_isDefinedBy: "[[!meta]]"
-exo__Asset_uid: a1b2c3d4-2222-4000-8000-000000000008
-exo__Instance_class:
-  - "[[exo__NumberProperty]]"
-exo__Property_domain: "[[meta__Cardinality]]"
-exo__Asset_description: Минимальное количество значений свойства
+core__Asset_isDefinedBy: "[[!meta]]"
+core__Asset_uid: a1b2c3d4-2222-4000-8000-000000000008
+core__Instance_class:
+  - "[[core__NumberProperty]]"
+core__Property_domain: "[[meta__Cardinality]]"
+core__Asset_description: Минимальное количество значений свойства
 ---
 

--- a/03 Knowledge/meta/meta__Class.md
+++ b/03 Knowledge/meta/meta__Class.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_uid: b2c3d4e5-meta-0002-0000-000000000001
-exo__Asset_isDefinedBy: "[[!meta]]"
-exo__Instance_class:
-  - "[[exo__Class]]"
-exo__Class_superClass:
+core__Asset_uid: b2c3d4e5-meta-0002-0000-000000000001
+core__Asset_isDefinedBy: "[[!meta]]"
+core__Instance_class:
+  - "[[core__Class]]"
+core__Class_superClass:
   - "[[owl__Class]]"
-exo__Class_description: Определение пользовательского класса в онтологии
+core__Class_description: Определение пользовательского класса в онтологии
 ---

--- a/03 Knowledge/meta/meta__Class_description.md
+++ b/03 Knowledge/meta/meta__Class_description.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_isDefinedBy: "[[!meta]]"
-exo__Asset_uid: a1b2c3d4-2222-4000-8000-000000000002
-exo__Instance_class:
-  - "[[exo__StringProperty]]"
-exo__Property_domain: "[[meta__Class]]"
-exo__Asset_description: Описание класса
+core__Asset_isDefinedBy: "[[!meta]]"
+core__Asset_uid: a1b2c3d4-2222-4000-8000-000000000002
+core__Instance_class:
+  - "[[core__StringProperty]]"
+core__Property_domain: "[[meta__Class]]"
+core__Asset_description: Описание класса
 ---
 

--- a/03 Knowledge/meta/meta__Class_superClass.md
+++ b/03 Knowledge/meta/meta__Class_superClass.md
@@ -1,10 +1,10 @@
 ---
-exo__Asset_isDefinedBy: "[[!meta]]"
-exo__Asset_uid: a1b2c3d4-2222-4000-8000-000000000001
-exo__Instance_class:
-  - "[[exo__ObjectProperty]]"
-exo__Property_domain: "[[meta__Class]]"
-exo__Property_range: "[[meta__Class]]"
-exo__Asset_description: Родительский класс (наследование)
+core__Asset_isDefinedBy: "[[!meta]]"
+core__Asset_uid: a1b2c3d4-2222-4000-8000-000000000001
+core__Instance_class:
+  - "[[core__ObjectProperty]]"
+core__Property_domain: "[[meta__Class]]"
+core__Property_range: "[[meta__Class]]"
+core__Asset_description: Родительский класс (наследование)
 ---
 

--- a/03 Knowledge/meta/meta__Constraint.md
+++ b/03 Knowledge/meta/meta__Constraint.md
@@ -1,7 +1,7 @@
 ---
-exo__Asset_uid: b2c3d4e5-meta-0004-0000-000000000001
-exo__Asset_isDefinedBy: "[[!meta]]"
-exo__Instance_class:
-  - "[[exo__Class]]"
-exo__Class_description: Ограничение на значение свойства
+core__Asset_uid: b2c3d4e5-meta-0004-0000-000000000001
+core__Asset_isDefinedBy: "[[!meta]]"
+core__Instance_class:
+  - "[[core__Class]]"
+core__Class_description: Ограничение на значение свойства
 ---

--- a/03 Knowledge/meta/meta__Constraint_message.md
+++ b/03 Knowledge/meta/meta__Constraint_message.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_isDefinedBy: "[[!meta]]"
-exo__Asset_uid: a1b2c3d4-2222-4000-8000-000000000007
-exo__Instance_class:
-  - "[[exo__StringProperty]]"
-exo__Property_domain: "[[meta__Constraint]]"
-exo__Asset_description: Сообщение об ошибке при нарушении ограничения
+core__Asset_isDefinedBy: "[[!meta]]"
+core__Asset_uid: a1b2c3d4-2222-4000-8000-000000000007
+core__Instance_class:
+  - "[[core__StringProperty]]"
+core__Property_domain: "[[meta__Constraint]]"
+core__Asset_description: Сообщение об ошибке при нарушении ограничения
 ---
 

--- a/03 Knowledge/meta/meta__Constraint_property.md
+++ b/03 Knowledge/meta/meta__Constraint_property.md
@@ -1,10 +1,10 @@
 ---
-exo__Asset_isDefinedBy: "[[!meta]]"
-exo__Asset_uid: a1b2c3d4-2222-4000-8000-000000000006
-exo__Instance_class:
-  - "[[exo__ObjectProperty]]"
-exo__Property_domain: "[[meta__Constraint]]"
-exo__Property_range: "[[meta__Property]]"
-exo__Asset_description: Свойство, к которому применяется ограничение
+core__Asset_isDefinedBy: "[[!meta]]"
+core__Asset_uid: a1b2c3d4-2222-4000-8000-000000000006
+core__Instance_class:
+  - "[[core__ObjectProperty]]"
+core__Property_domain: "[[meta__Constraint]]"
+core__Property_range: "[[meta__Property]]"
+core__Asset_description: Свойство, к которому применяется ограничение
 ---
 

--- a/03 Knowledge/meta/meta__Property.md
+++ b/03 Knowledge/meta/meta__Property.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_uid: b2c3d4e5-meta-0003-0000-000000000001
-exo__Asset_isDefinedBy: "[[!meta]]"
-exo__Instance_class:
-  - "[[exo__Class]]"
-exo__Class_superClass:
+core__Asset_uid: b2c3d4e5-meta-0003-0000-000000000001
+core__Asset_isDefinedBy: "[[!meta]]"
+core__Instance_class:
+  - "[[core__Class]]"
+core__Class_superClass:
   - "[[rdf__Property]]"
-exo__Class_description: Определение свойства класса
+core__Class_description: Определение свойства класса
 ---

--- a/03 Knowledge/meta/meta__Property_description.md
+++ b/03 Knowledge/meta/meta__Property_description.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_isDefinedBy: "[[!meta]]"
-exo__Asset_uid: a1b2c3d4-2222-4000-8000-000000000005
-exo__Instance_class:
-  - "[[exo__StringProperty]]"
-exo__Property_domain: "[[meta__Property]]"
-exo__Asset_description: Описание свойства
+core__Asset_isDefinedBy: "[[!meta]]"
+core__Asset_uid: a1b2c3d4-2222-4000-8000-000000000005
+core__Instance_class:
+  - "[[core__StringProperty]]"
+core__Property_domain: "[[meta__Property]]"
+core__Asset_description: Описание свойства
 ---
 

--- a/03 Knowledge/meta/meta__Property_domain.md
+++ b/03 Knowledge/meta/meta__Property_domain.md
@@ -1,11 +1,11 @@
 ---
-exo__Asset_isDefinedBy: "[[!meta]]"
-exo__Asset_uid: a1b2c3d4-2222-4000-8000-000000000003
-exo__Instance_class:
-  - "[[exo__ObjectProperty]]"
-exo__Property_domain: "[[meta__Property]]"
-exo__Property_range: "[[meta__Class]]"
-exo__Asset_description: Класс, к которому применимо это свойство
-exo__Property_superProperty: "[[rdfs__domain]]"
+core__Asset_isDefinedBy: "[[!meta]]"
+core__Asset_uid: a1b2c3d4-2222-4000-8000-000000000003
+core__Instance_class:
+  - "[[core__ObjectProperty]]"
+core__Property_domain: "[[meta__Property]]"
+core__Property_range: "[[meta__Class]]"
+core__Asset_description: Класс, к которому применимо это свойство
+core__Property_superProperty: "[[rdfs__domain]]"
 ---
 

--- a/03 Knowledge/meta/meta__Property_range.md
+++ b/03 Knowledge/meta/meta__Property_range.md
@@ -1,11 +1,11 @@
 ---
-exo__Asset_isDefinedBy: "[[!meta]]"
-exo__Asset_uid: a1b2c3d4-2222-4000-8000-000000000004
-exo__Instance_class:
-  - "[[exo__ObjectProperty]]"
-exo__Property_domain: "[[meta__Property]]"
-exo__Property_range: "[[meta__Class]]"
-exo__Asset_description: Класс значений этого свойства
-exo__Property_superProperty: "[[rdfs__range]]"
+core__Asset_isDefinedBy: "[[!meta]]"
+core__Asset_uid: a1b2c3d4-2222-4000-8000-000000000004
+core__Instance_class:
+  - "[[core__ObjectProperty]]"
+core__Property_domain: "[[meta__Property]]"
+core__Property_range: "[[meta__Class]]"
+core__Asset_description: Класс значений этого свойства
+core__Property_superProperty: "[[rdfs__range]]"
 ---
 

--- a/03 Knowledge/owl/!owl.md
+++ b/03 Knowledge/owl/!owl.md
@@ -1,8 +1,8 @@
 ---
-exo__Asset_uid: 00000000-0000-0000-0000-000000000010
-exo__Asset_createdAt: 2025-01-01T00:00:00
-exo__Instance_class:
-  - "[[exo__Ontology]]"
-exo__Ontology_url: http://www.w3.org/2002/07/owl#
-exo__Asset_description: Web Ontology Language
+core__Asset_uid: 00000000-0000-0000-0000-000000000010
+core__Asset_createdAt: 2025-01-01T00:00:00
+core__Instance_class:
+  - "[[core__Ontology]]"
+core__Ontology_url: http://www.w3.org/2002/07/owl#
+core__Asset_description: Web Ontology Language
 ---

--- a/03 Knowledge/owl/owl__DatatypeProperty.md
+++ b/03 Knowledge/owl/owl__DatatypeProperty.md
@@ -1,8 +1,8 @@
 ---
-exo__Asset_uid: 10000000-0000-0000-0000-000000000104
-exo__Asset_isDefinedBy: "[[!owl]]"
-exo__Asset_createdAt: 2025-01-01T00:00:00
-exo__Instance_class:
-  - "[[exo__Class]]"
-exo__Class_description: OWL Datatype Property — свойство со значением-литералом
+core__Asset_uid: 10000000-0000-0000-0000-000000000104
+core__Asset_isDefinedBy: "[[!owl]]"
+core__Asset_createdAt: 2025-01-01T00:00:00
+core__Instance_class:
+  - "[[core__Class]]"
+core__Class_description: OWL Datatype Property — свойство со значением-литералом
 ---

--- a/03 Knowledge/owl/owl__ObjectProperty.md
+++ b/03 Knowledge/owl/owl__ObjectProperty.md
@@ -1,8 +1,8 @@
 ---
-exo__Asset_uid: 10000000-0000-0000-0000-000000000103
-exo__Asset_isDefinedBy: "[[!owl]]"
-exo__Asset_createdAt: 2025-01-01T00:00:00
-exo__Instance_class:
-  - "[[exo__Class]]"
-exo__Class_description: OWL Object Property — свойство, связывающее два ресурса
+core__Asset_uid: 10000000-0000-0000-0000-000000000103
+core__Asset_isDefinedBy: "[[!owl]]"
+core__Asset_createdAt: 2025-01-01T00:00:00
+core__Instance_class:
+  - "[[core__Class]]"
+core__Class_description: OWL Object Property — свойство, связывающее два ресурса
 ---

--- a/03 Knowledge/presentation/!presentation.md
+++ b/03 Knowledge/presentation/!presentation.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_uid: e5f6a7b8-pres-0001-0000-000000000001
-exo__Asset_label: Presentation Layer
-exo__Asset_description: Платформо-специфичные реализации UI
-exo__Instance_class:
-  - "[[exo__Ontology]]"
+core__Asset_uid: e5f6a7b8-pres-0001-0000-000000000001
+core__Asset_label: Presentation Layer
+core__Asset_description: Платформо-специфичные реализации UI
+core__Instance_class:
+  - "[[core__Ontology]]"
 uri: https://exocortex.my/ontology/presentation#
 prefix: pres
 ---

--- a/03 Knowledge/presentation/obsidian/!obsidian.md
+++ b/03 Knowledge/presentation/obsidian/!obsidian.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_uid: e5f6a7b8-obs0-0001-0000-000000000001
-exo__Asset_label: Obsidian Presentation
-exo__Asset_description: Реализация слоя представления для Obsidian
-exo__Instance_class:
-  - "[[exo__Ontology]]"
+core__Asset_uid: e5f6a7b8-obs0-0001-0000-000000000001
+core__Asset_label: Obsidian Presentation
+core__Asset_description: Реализация слоя представления для Obsidian
+core__Instance_class:
+  - "[[core__Ontology]]"
 uri: https://exocortex.my/ontology/presentation/obsidian#
 prefix: obs
 ---

--- a/03 Knowledge/presentation/obsidian/groundings/!groundings.md
+++ b/03 Knowledge/presentation/obsidian/groundings/!groundings.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_uid: e5f6a7b8-grnd-0001-0000-000000000001
-exo__Asset_label: Obsidian Groundings
-exo__Asset_description: Привязка команд к Obsidian API
-exo__Instance_class:
-  - "[[exo__Ontology]]"
+core__Asset_uid: e5f6a7b8-grnd-0001-0000-000000000001
+core__Asset_label: Obsidian Groundings
+core__Asset_description: Привязка команд к Obsidian API
+core__Instance_class:
+  - "[[core__Ontology]]"
 uri: https://exocortex.my/ontology/presentation/obsidian/groundings#
 prefix: grnd
 ---

--- a/03 Knowledge/presentation/obsidian/groundings/grnd__CreateTaskGrounding.md
+++ b/03 Knowledge/presentation/obsidian/groundings/grnd__CreateTaskGrounding.md
@@ -1,7 +1,7 @@
 ---
-exo__Asset_uid: e5f6a7b8-grnd-0003-0000-000000000001
-exo__Asset_isDefinedBy: "[[!groundings]]"
-exo__Instance_class:
+core__Asset_uid: e5f6a7b8-grnd-0003-0000-000000000001
+core__Asset_isDefinedBy: "[[!groundings]]"
+core__Instance_class:
   - "[[grnd__Grounding]]"
 grnd__Grounding_command: "[[cmd__CreateTask]]"
 grnd__Grounding_platform: Obsidian

--- a/03 Knowledge/presentation/obsidian/groundings/grnd__Grounding.md
+++ b/03 Knowledge/presentation/obsidian/groundings/grnd__Grounding.md
@@ -1,7 +1,7 @@
 ---
-exo__Asset_uid: e5f6a7b8-grnd-0002-0000-000000000001
-exo__Asset_isDefinedBy: "[[!groundings]]"
-exo__Instance_class:
-  - "[[exo__Class]]"
-exo__Class_description: Привязка абстрактной команды к Obsidian API
+core__Asset_uid: e5f6a7b8-grnd-0002-0000-000000000001
+core__Asset_isDefinedBy: "[[!groundings]]"
+core__Instance_class:
+  - "[[core__Class]]"
+core__Class_description: Привязка абстрактной команды к Obsidian API
 ---

--- a/03 Knowledge/presentation/obsidian/groundings/grnd__Grounding_capabilities.md
+++ b/03 Knowledge/presentation/obsidian/groundings/grnd__Grounding_capabilities.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_isDefinedBy: "[[!groundings]]"
-exo__Asset_uid: a1b2c3d4-5555-4000-8000-000000000007
-exo__Instance_class:
-  - "[[exo__StringProperty]]"
-exo__Property_domain: "[[grnd__Grounding]]"
-exo__Asset_description: Требуемые возможности платформы (массив строк)
+core__Asset_isDefinedBy: "[[!groundings]]"
+core__Asset_uid: a1b2c3d4-5555-4000-8000-000000000007
+core__Instance_class:
+  - "[[core__StringProperty]]"
+core__Property_domain: "[[grnd__Grounding]]"
+core__Asset_description: Требуемые возможности платформы (массив строк)
 ---
 

--- a/03 Knowledge/presentation/obsidian/groundings/grnd__Grounding_command.md
+++ b/03 Knowledge/presentation/obsidian/groundings/grnd__Grounding_command.md
@@ -1,10 +1,10 @@
 ---
-exo__Asset_isDefinedBy: "[[!groundings]]"
-exo__Asset_uid: a1b2c3d4-5555-4000-8000-000000000004
-exo__Instance_class:
-  - "[[exo__ObjectProperty]]"
-exo__Property_domain: "[[grnd__Grounding]]"
-exo__Property_range: "[[cmd__Command]]"
-exo__Asset_description: Команда, которую реализует grounding
+core__Asset_isDefinedBy: "[[!groundings]]"
+core__Asset_uid: a1b2c3d4-5555-4000-8000-000000000004
+core__Instance_class:
+  - "[[core__ObjectProperty]]"
+core__Property_domain: "[[grnd__Grounding]]"
+core__Property_range: "[[cmd__Command]]"
+core__Asset_description: Команда, которую реализует grounding
 ---
 

--- a/03 Knowledge/presentation/obsidian/groundings/grnd__Grounding_platform.md
+++ b/03 Knowledge/presentation/obsidian/groundings/grnd__Grounding_platform.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_isDefinedBy: "[[!groundings]]"
-exo__Asset_uid: a1b2c3d4-5555-4000-8000-000000000005
-exo__Instance_class:
-  - "[[exo__StringProperty]]"
-exo__Property_domain: "[[grnd__Grounding]]"
-exo__Asset_description: Целевая платформа (Obsidian, VSCode, etc.)
+core__Asset_isDefinedBy: "[[!groundings]]"
+core__Asset_uid: a1b2c3d4-5555-4000-8000-000000000005
+core__Instance_class:
+  - "[[core__StringProperty]]"
+core__Property_domain: "[[grnd__Grounding]]"
+core__Asset_description: Целевая платформа (Obsidian, VSCode, etc.)
 ---
 

--- a/03 Knowledge/presentation/obsidian/groundings/grnd__Grounding_status.md
+++ b/03 Knowledge/presentation/obsidian/groundings/grnd__Grounding_status.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_isDefinedBy: "[[!groundings]]"
-exo__Asset_uid: a1b2c3d4-5555-4000-8000-000000000006
-exo__Instance_class:
-  - "[[exo__StringProperty]]"
-exo__Property_domain: "[[grnd__Grounding]]"
-exo__Asset_description: Статус реализации (planned, in-progress, implemented, deprecated)
+core__Asset_isDefinedBy: "[[!groundings]]"
+core__Asset_uid: a1b2c3d4-5555-4000-8000-000000000006
+core__Instance_class:
+  - "[[core__StringProperty]]"
+core__Property_domain: "[[grnd__Grounding]]"
+core__Asset_description: Статус реализации (planned, in-progress, implemented, deprecated)
 ---
 

--- a/03 Knowledge/presentation/obsidian/layouts/!layouts.md
+++ b/03 Knowledge/presentation/obsidian/layouts/!layouts.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_uid: e5f6a7b8-layo-0001-0000-000000000001
-exo__Asset_label: Obsidian Layouts
-exo__Asset_description: Визуальные шаблоны для отображения заметок
-exo__Instance_class:
-  - "[[exo__Ontology]]"
+core__Asset_uid: e5f6a7b8-layo-0001-0000-000000000001
+core__Asset_label: Obsidian Layouts
+core__Asset_description: Визуальные шаблоны для отображения заметок
+core__Instance_class:
+  - "[[core__Ontology]]"
 uri: https://exocortex.my/ontology/presentation/obsidian/layouts#
 prefix: layout
 ---

--- a/03 Knowledge/presentation/obsidian/layouts/layout__Layout.md
+++ b/03 Knowledge/presentation/obsidian/layouts/layout__Layout.md
@@ -1,7 +1,7 @@
 ---
-exo__Asset_uid: e5f6a7b8-layo-0002-0000-000000000001
-exo__Asset_isDefinedBy: "[[!layouts]]"
-exo__Instance_class:
-  - "[[exo__Class]]"
-exo__Class_description: Визуальный шаблон для отображения заметки
+core__Asset_uid: e5f6a7b8-layo-0002-0000-000000000001
+core__Asset_isDefinedBy: "[[!layouts]]"
+core__Instance_class:
+  - "[[core__Class]]"
+core__Class_description: Визуальный шаблон для отображения заметки
 ---

--- a/03 Knowledge/presentation/obsidian/layouts/layout__Layout_isDefault.md
+++ b/03 Knowledge/presentation/obsidian/layouts/layout__Layout_isDefault.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_isDefinedBy: "[[!layouts]]"
-exo__Asset_uid: a1b2c3d4-5555-4000-8000-000000000003
-exo__Instance_class:
-  - "[[exo__BooleanProperty]]"
-exo__Property_domain: "[[layout__Layout]]"
-exo__Asset_description: Является ли layout'ом по умолчанию для типа
+core__Asset_isDefinedBy: "[[!layouts]]"
+core__Asset_uid: a1b2c3d4-5555-4000-8000-000000000003
+core__Instance_class:
+  - "[[core__BooleanProperty]]"
+core__Property_domain: "[[layout__Layout]]"
+core__Asset_description: Является ли layout'ом по умолчанию для типа
 ---
 

--- a/03 Knowledge/presentation/obsidian/layouts/layout__Layout_sections.md
+++ b/03 Knowledge/presentation/obsidian/layouts/layout__Layout_sections.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_isDefinedBy: "[[!layouts]]"
-exo__Asset_uid: a1b2c3d4-5555-4000-8000-000000000002
-exo__Instance_class:
-  - "[[exo__ObjectProperty]]"
-exo__Property_domain: "[[layout__Layout]]"
-exo__Asset_description: Секции layout'а (упорядоченный список)
+core__Asset_isDefinedBy: "[[!layouts]]"
+core__Asset_uid: a1b2c3d4-5555-4000-8000-000000000002
+core__Instance_class:
+  - "[[core__ObjectProperty]]"
+core__Property_domain: "[[layout__Layout]]"
+core__Asset_description: Секции layout'а (упорядоченный список)
 ---
 

--- a/03 Knowledge/presentation/obsidian/layouts/layout__Layout_targetType.md
+++ b/03 Knowledge/presentation/obsidian/layouts/layout__Layout_targetType.md
@@ -1,10 +1,10 @@
 ---
-exo__Asset_isDefinedBy: "[[!layouts]]"
-exo__Asset_uid: a1b2c3d4-5555-4000-8000-000000000001
-exo__Instance_class:
-  - "[[exo__ObjectProperty]]"
-exo__Property_domain: "[[layout__Layout]]"
-exo__Property_range: "[[meta__Class]]"
-exo__Asset_description: Тип сущности, для которой предназначен layout
+core__Asset_isDefinedBy: "[[!layouts]]"
+core__Asset_uid: a1b2c3d4-5555-4000-8000-000000000001
+core__Instance_class:
+  - "[[core__ObjectProperty]]"
+core__Property_domain: "[[layout__Layout]]"
+core__Property_range: "[[meta__Class]]"
+core__Asset_description: Тип сущности, для которой предназначен layout
 ---
 

--- a/03 Knowledge/presentation/obsidian/layouts/layout__TaskLayout.md
+++ b/03 Knowledge/presentation/obsidian/layouts/layout__TaskLayout.md
@@ -1,7 +1,7 @@
 ---
-exo__Asset_uid: e5f6a7b8-layo-0003-0000-000000000001
-exo__Asset_isDefinedBy: "[[!layouts]]"
-exo__Instance_class:
+core__Asset_uid: e5f6a7b8-layo-0003-0000-000000000001
+core__Asset_isDefinedBy: "[[!layouts]]"
+core__Instance_class:
   - "[[layout__Layout]]"
 layout__Layout_targetType: "[[ems__Task]]"
 layout__Layout_isDefault: true

--- a/03 Knowledge/presentation/obsidian/ui/!ui.md
+++ b/03 Knowledge/presentation/obsidian/ui/!ui.md
@@ -1,9 +1,9 @@
 ---
-exo__Asset_uid: e5f6a7b8-ui00-0001-0000-000000000001
-exo__Asset_label: Obsidian UI Components
-exo__Asset_description: UI-компоненты для Obsidian (модалки, уведомления)
-exo__Instance_class:
-  - "[[exo__Ontology]]"
+core__Asset_uid: e5f6a7b8-ui00-0001-0000-000000000001
+core__Asset_label: Obsidian UI Components
+core__Asset_description: UI-компоненты для Obsidian (модалки, уведомления)
+core__Instance_class:
+  - "[[core__Ontology]]"
 uri: https://exocortex.my/ontology/presentation/obsidian/ui#
 prefix: ui
 ---

--- a/03 Knowledge/rdf/!rdf.md
+++ b/03 Knowledge/rdf/!rdf.md
@@ -1,8 +1,8 @@
 ---
-exo__Asset_uid: 00000000-0000-0000-0000-000000000011
-exo__Asset_createdAt: 2025-01-01T00:00:00
-exo__Instance_class:
-  - "[[exo__Ontology]]"
-exo__Ontology_url: http://www.w3.org/1999/02/22-rdf-syntax-ns#
-exo__Asset_description: Resource Description Framework
+core__Asset_uid: 00000000-0000-0000-0000-000000000011
+core__Asset_createdAt: 2025-01-01T00:00:00
+core__Instance_class:
+  - "[[core__Ontology]]"
+core__Ontology_url: http://www.w3.org/1999/02/22-rdf-syntax-ns#
+core__Asset_description: Resource Description Framework
 ---

--- a/03 Knowledge/rdf/rdf__Property.md
+++ b/03 Knowledge/rdf/rdf__Property.md
@@ -1,8 +1,8 @@
 ---
-exo__Asset_uid: 10000000-0000-0000-0000-000000000110
-exo__Asset_isDefinedBy: "[[!rdf]]"
-exo__Asset_createdAt: 2025-01-01T00:00:00
-exo__Instance_class:
-  - "[[exo__Class]]"
-exo__Class_description: RDF Property — базовый класс для всех свойств в RDF
+core__Asset_uid: 10000000-0000-0000-0000-000000000110
+core__Asset_isDefinedBy: "[[!rdf]]"
+core__Asset_createdAt: 2025-01-01T00:00:00
+core__Instance_class:
+  - "[[core__Class]]"
+core__Class_description: RDF Property — базовый класс для всех свойств в RDF
 ---

--- a/03 Knowledge/rdfs/!rdfs.md
+++ b/03 Knowledge/rdfs/!rdfs.md
@@ -1,10 +1,10 @@
 ---
-exo__Asset_uid: 00000000-0000-0000-0000-000000000012
-exo__Asset_createdAt: 2025-01-01T00:00:00
-exo__Asset_description: RDF Schema
-exo__Instance_class:
-  - "[[exo__Ontology]]"
-exo__Ontology_url: http://www.w3.org/2000/01/rdf-schema#
-exo__Ontology_imports:
+core__Asset_uid: 00000000-0000-0000-0000-000000000012
+core__Asset_createdAt: 2025-01-01T00:00:00
+core__Asset_description: RDF Schema
+core__Instance_class:
+  - "[[core__Ontology]]"
+core__Ontology_url: http://www.w3.org/2000/01/rdf-schema#
+core__Ontology_imports:
   - "[[!rdf]]"
 ---

--- a/03 Knowledge/rdfs/rdfs__Class.md
+++ b/03 Knowledge/rdfs/rdfs__Class.md
@@ -1,10 +1,10 @@
 ---
-exo__Asset_uid: 10000000-0000-0000-0000-000000000113
-exo__Asset_isDefinedBy: "[[!rdfs]]"
-exo__Asset_createdAt: 2025-01-01T00:00:00
-exo__Instance_class:
-  - "[[exo__Class]]"
-exo__Class_superClass:
+core__Asset_uid: 10000000-0000-0000-0000-000000000113
+core__Asset_isDefinedBy: "[[!rdfs]]"
+core__Asset_createdAt: 2025-01-01T00:00:00
+core__Instance_class:
+  - "[[core__Class]]"
+core__Class_superClass:
   - "[[rdfs__Resource]]"
-exo__Class_description: RDFS Class — класс всех классов в RDFS
+core__Class_description: RDFS Class — класс всех классов в RDFS
 ---

--- a/03 Knowledge/rdfs/rdfs__Resource.md
+++ b/03 Knowledge/rdfs/rdfs__Resource.md
@@ -1,8 +1,8 @@
 ---
-exo__Asset_uid: 10000000-0000-0000-0000-000000000100
-exo__Asset_isDefinedBy: "[[!rdfs]]"
-exo__Asset_createdAt: 2025-01-01T00:00:00
-exo__Instance_class:
-  - "[[exo__Class]]"
-exo__Class_description: Базовый класс RDFS — все сущности являются ресурсами
+core__Asset_uid: 10000000-0000-0000-0000-000000000100
+core__Asset_isDefinedBy: "[[!rdfs]]"
+core__Asset_createdAt: 2025-01-01T00:00:00
+core__Instance_class:
+  - "[[core__Class]]"
+core__Class_description: Базовый класс RDFS — все сущности являются ресурсами
 ---

--- a/03 Knowledge/rdfs/rdfs__domain.md
+++ b/03 Knowledge/rdfs/rdfs__domain.md
@@ -1,10 +1,10 @@
 ---
-exo__Asset_uid: 10000000-0000-0000-0000-000000000111
-exo__Asset_isDefinedBy: "[[!rdfs]]"
-exo__Asset_createdAt: 2025-01-01T00:00:00
-exo__Instance_class:
+core__Asset_uid: 10000000-0000-0000-0000-000000000111
+core__Asset_isDefinedBy: "[[!rdfs]]"
+core__Asset_createdAt: 2025-01-01T00:00:00
+core__Instance_class:
   - "[[rdf__Property]]"
-exo__Property_domain: "[[rdf__Property]]"
-exo__Property_range: "[[rdfs__Class]]"
-exo__Asset_description: RDFS domain — указывает класс, к которому применимо свойство
+core__Property_domain: "[[rdf__Property]]"
+core__Property_range: "[[rdfs__Class]]"
+core__Asset_description: RDFS domain — указывает класс, к которому применимо свойство
 ---

--- a/03 Knowledge/rdfs/rdfs__range.md
+++ b/03 Knowledge/rdfs/rdfs__range.md
@@ -1,10 +1,10 @@
 ---
-exo__Asset_uid: 10000000-0000-0000-0000-000000000112
-exo__Asset_isDefinedBy: "[[!rdfs]]"
-exo__Asset_createdAt: 2025-01-01T00:00:00
-exo__Instance_class:
+core__Asset_uid: 10000000-0000-0000-0000-000000000112
+core__Asset_isDefinedBy: "[[!rdfs]]"
+core__Asset_createdAt: 2025-01-01T00:00:00
+core__Instance_class:
   - "[[rdf__Property]]"
-exo__Property_domain: "[[rdf__Property]]"
-exo__Property_range: "[[rdfs__Class]]"
-exo__Asset_description: RDFS range — указывает класс или тип значения свойства
+core__Property_domain: "[[rdf__Property]]"
+core__Property_range: "[[rdfs__Class]]"
+core__Asset_description: RDFS range — указывает класс или тип значения свойства
 ---


### PR DESCRIPTION
## Summary

All references to `exo__` classes and properties renamed to `core__` to make the ontology repository self-contained.

## Changes

### Renamed classes
- `exo__Class` → `core__Class`
- `exo__Property` → `core__Property`
- `exo__ObjectProperty` → `core__ObjectProperty`
- `exo__StringProperty` → `core__StringProperty`
- `exo__NumberProperty` → `core__NumberProperty`
- `exo__BooleanProperty` → `core__BooleanProperty`
- `exo__DateProperty` → `core__DateProperty`
- `exo__DateTimeProperty` → `core__DateTimeProperty`
- `exo__Ontology` → `core__Ontology`
- `exo__Resource` → `core__Resource`
- `exo__DatatypeProperty` → `core__DatatypeProperty`

### Renamed property names
- `exo__Asset_uid:` → `core__Asset_uid:`
- `exo__Asset_isDefinedBy:` → `core__Asset_isDefinedBy:`
- `exo__Instance_class:` → `core__Instance_class:`
- `exo__Class_superClass:` → `core__Class_superClass:`
- etc.

### Added new core classes
11 new files in `03 Knowledge/core/`:
- `core__Resource.md` (root)
- `core__Class.md` (metaclass)
- `core__Property.md`, `core__ObjectProperty.md`, `core__DatatypeProperty.md`
- `core__StringProperty.md`, `core__NumberProperty.md`, `core__BooleanProperty.md`
- `core__DateProperty.md`, `core__DateTimeProperty.md`
- `core__Ontology.md`

## Result

The ontology repository is now **self-contained** with no external dependencies on `exo__*` classes.

## Test plan
- [ ] Verify all files have valid YAML frontmatter
- [ ] Check no `exo__` references remain