### PR TITLE
docs: add UML class diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,203 @@
             └── !ui.md
 ```
 
+## Диаграмма классов
+
+```mermaid
+classDiagram
+    direction TB
+
+    %% =========================================================================
+    %% CORE LAYER (Shared Kernel)
+    %% =========================================================================
+    namespace core {
+        class Resource {
+            <<root>>
+        }
+        class Asset {
+            +label: String
+            +description: String
+            +uri: String
+            +created: DateTime
+            +modified: DateTime
+        }
+        class Reference {
+            +target: Asset
+        }
+        class Relation {
+            +source: Asset
+            +target: Asset
+            +type: ObjectProperty
+        }
+        class Class {
+            <<metaclass>>
+        }
+        class Property
+        class ObjectProperty
+        class DatatypeProperty
+        class StringProperty
+        class NumberProperty
+        class BooleanProperty
+        class DateProperty
+        class DateTimeProperty
+        class Ontology {
+            +url: String
+        }
+    }
+
+    Resource <|-- Asset
+    Resource <|-- Class
+    Resource <|-- Property
+    Resource <|-- Ontology
+    Asset <|-- Reference
+    Asset <|-- Relation
+    Property <|-- ObjectProperty
+    Property <|-- DatatypeProperty
+    DatatypeProperty <|-- StringProperty
+    DatatypeProperty <|-- NumberProperty
+    DatatypeProperty <|-- BooleanProperty
+    DatatypeProperty <|-- DateProperty
+    DatatypeProperty <|-- DateTimeProperty
+
+    %% =========================================================================
+    %% META LAYER
+    %% =========================================================================
+    namespace meta {
+        class MetaClass["meta__Class"] {
+            +superClass: Class[]
+            +description: String
+        }
+        class MetaProperty["meta__Property"] {
+            +domain: Class
+            +range: Class
+            +description: String
+        }
+        class Constraint {
+            +property: Property
+            +message: String
+        }
+        class Cardinality {
+            +min: Number
+            +max: Number
+        }
+    }
+
+    Class <|.. MetaClass : extends
+    Property <|.. MetaProperty : extends
+    Resource <|-- Constraint
+    Resource <|-- Cardinality
+
+    %% =========================================================================
+    %% DOMAIN LAYER - EMS
+    %% =========================================================================
+    namespace domain_ems {
+        class Effort {
+            <<mixin>>
+            +startTimestamp: DateTime
+            +endTimestamp: DateTime
+        }
+        class Task {
+            +project: Project
+            +area: Area
+            +prototype: Prototype
+            +priority: Number
+            +dueDate: Date
+        }
+        class Project {
+            +area: Area
+            +status: String
+            +dueDate: Date
+        }
+        class Area {
+            +parent: Area
+        }
+        class Prototype {
+            +area: Area
+            +defaultDuration: Number
+        }
+    }
+
+    Asset <|-- Task
+    Asset <|-- Project
+    Asset <|-- Area
+    Asset <|-- Prototype
+    Effort <|.. Task : mixin
+    Task --> Project : project
+    Task --> Area : area
+    Task --> Prototype : prototype
+    Project --> Area : area
+    Area --> Area : parent
+    Prototype --> Area : area
+
+    %% =========================================================================
+    %% APPLICATION LAYER
+    %% =========================================================================
+    namespace application {
+        class Command {
+            <<abstract>>
+            +name: String
+            +description: String
+            +category: String
+            +hotkey: String
+            +contextType: Class
+            +targetType: Class
+            +form: Form
+        }
+        class CreateTask
+        class StartTask
+        class CompleteTask
+        class Search
+        class Form {
+            +fields: FormField[]
+        }
+        class FormField {
+            <<abstract>>
+            +name: String
+            +label: String
+            +type: String
+            +required: Boolean
+        }
+        class LinkField {
+            +targetType: Class
+        }
+    }
+
+    Command <|-- CreateTask
+    Command <|-- StartTask
+    Command <|-- CompleteTask
+    Command <|-- Search
+    FormField <|-- LinkField
+    Command --> Form : form
+    Command --> Class : contextType
+    Form --> FormField : fields
+
+    %% =========================================================================
+    %% PRESENTATION LAYER
+    %% =========================================================================
+    namespace presentation {
+        class Layout {
+            +targetType: Class
+            +sections: String[]
+            +isDefault: Boolean
+        }
+        class TaskLayout
+        class Grounding {
+            +command: Command
+            +platform: String
+            +status: String
+            +capabilities: String[]
+        }
+        class CreateTaskGrounding
+    }
+
+    Layout <|-- TaskLayout
+    Grounding <|-- CreateTaskGrounding
+    Layout --> Class : targetType
+    Grounding --> Command : command
+```
+
+> 📁 PlantUML версия: [docs/class-diagram.puml](./docs/class-diagram.puml)
+
 ## Принципы архитектуры
 
 ### Слои (Clean Architecture)

--- a/docs/class-diagram.puml
+++ b/docs/class-diagram.puml
@@ -1,0 +1,297 @@
+@startuml exocortex-public-ontologies
+
+' =============================================================================
+' EXOCORTEX PUBLIC ONTOLOGIES - CLASS DIAGRAM
+' Architecture: Clean Architecture + DDD
+' =============================================================================
+
+skinparam classAttributeIconSize 0
+skinparam linetype ortho
+skinparam packageStyle rectangle
+skinparam groupInheritance 2
+
+' =============================================================================
+' CORE LAYER (Shared Kernel)
+' =============================================================================
+package "core" <<Rectangle>> #E8F5E9 {
+
+    class "core__Resource" as Resource <<root>> {
+        --
+        Корень иерархии
+    }
+
+    class "core__Asset" as Asset {
+        + label : String
+        + description : String
+        + uri : String
+        + created : DateTime
+        + modified : DateTime
+        --
+        Базовая единица знаний
+    }
+
+    class "core__Reference" as Reference {
+        + target : Asset
+        --
+        Ссылка на другой Asset
+    }
+
+    class "core__Relation" as Relation {
+        + source : Asset
+        + target : Asset
+        + type : ObjectProperty
+        --
+        Типизированная связь
+    }
+
+    class "core__Class" as Class <<metaclass>> {
+        --
+        Метакласс
+    }
+
+    class "core__Property" as Property {
+        --
+        Базовый класс свойств
+    }
+
+    class "core__ObjectProperty" as ObjectProperty {
+        --
+        Ссылка на Asset
+    }
+
+    class "core__DatatypeProperty" as DatatypeProperty {
+        --
+        Примитивное значение
+    }
+
+    class "core__StringProperty" as StringProperty
+    class "core__NumberProperty" as NumberProperty
+    class "core__BooleanProperty" as BooleanProperty
+    class "core__DateProperty" as DateProperty
+    class "core__DateTimeProperty" as DateTimeProperty
+
+    class "core__Ontology" as Ontology {
+        + url : String
+        --
+        Контейнер онтологии
+    }
+
+    ' Inheritance
+    Asset --|> Resource
+    Reference --|> Asset
+    Relation --|> Asset
+    Class --|> Resource
+    Property --|> Resource
+    ObjectProperty --|> Property
+    DatatypeProperty --|> Property
+    StringProperty --|> DatatypeProperty
+    NumberProperty --|> DatatypeProperty
+    BooleanProperty --|> DatatypeProperty
+    DateProperty --|> DatatypeProperty
+    DateTimeProperty --|> DatatypeProperty
+    Ontology --|> Resource
+}
+
+' =============================================================================
+' META LAYER (Schema Definitions)
+' =============================================================================
+package "meta" <<Rectangle>> #E3F2FD {
+
+    class "meta__Class" as MetaClass {
+        + superClass : Class[]
+        + description : String
+        --
+        Расширение core__Class
+    }
+
+    class "meta__Property" as MetaProperty {
+        + domain : Class
+        + range : Class|Datatype
+        + description : String
+        --
+        Расширение core__Property
+    }
+
+    class "meta__Constraint" as Constraint {
+        + property : Property
+        + message : String
+        --
+        Ограничение на свойство
+    }
+
+    class "meta__Cardinality" as Cardinality {
+        + min : Number
+        + max : Number
+        --
+        Кардинальность свойства
+    }
+
+    MetaClass ..|> Class : extends
+    MetaProperty ..|> Property : extends
+    Constraint --|> Resource
+    Cardinality --|> Resource
+}
+
+' =============================================================================
+' DOMAIN LAYER - EMS (Effort Management System)
+' =============================================================================
+package "domain/ems" <<Rectangle>> #FFF3E0 {
+
+    class "ems__Effort" as Effort <<mixin>> {
+        + startTimestamp : DateTime
+        + endTimestamp : DateTime
+        --
+        {abstract} Трекинг времени
+    }
+
+    class "ems__Task" as Task {
+        + project : Project
+        + area : Area
+        + prototype : Prototype
+        + priority : Number
+        + dueDate : Date
+        --
+        Задача
+    }
+
+    class "ems__Project" as Project {
+        + area : Area
+        + status : String
+        + dueDate : Date
+        --
+        Проект
+    }
+
+    class "ems__Area" as Area {
+        + parent : Area
+        --
+        Область ответственности
+    }
+
+    class "ems__Prototype" as Prototype {
+        + area : Area
+        + defaultDuration : Number
+        --
+        Шаблон задачи
+    }
+
+    ' Inheritance
+    Task --|> Asset
+    Task ..|> Effort : mixin
+    Project --|> Asset
+    Area --|> Asset
+    Prototype --|> Asset
+
+    ' Associations
+    Task --> Project : project
+    Task --> Area : area
+    Task --> Prototype : prototype
+    Project --> Area : area
+    Area --> Area : parent
+    Prototype --> Area : area
+}
+
+' =============================================================================
+' APPLICATION LAYER (Use Cases)
+' =============================================================================
+package "application" <<Rectangle>> #F3E5F5 {
+
+    package "commands" {
+        class "cmd__Command" as Command <<abstract>> {
+            + name : String
+            + description : String
+            + category : String
+            + hotkey : String
+            + contextType : Class
+            + targetType : Class
+            + form : Form
+            --
+            {abstract} Use Case
+        }
+
+        class "cmd__CreateTask" as CreateTask
+        class "cmd__StartTask" as StartTask
+        class "cmd__CompleteTask" as CompleteTask
+        class "cmd__Search" as Search
+
+        CreateTask --|> Command
+        StartTask --|> Command
+        CompleteTask --|> Command
+        Search --|> Command
+    }
+
+    package "forms" {
+        class "form__Form" as Form {
+            + fields : FormField[]
+            --
+            Форма ввода
+        }
+
+        class "form__FormField" as FormField <<abstract>> {
+            + name : String
+            + label : String
+            + type : String
+            + required : Boolean
+            + property : Property
+            --
+            {abstract} Поле формы
+        }
+
+        class "form__LinkField" as LinkField {
+            + targetType : Class
+            --
+            Поле-ссылка
+        }
+
+        LinkField --|> FormField
+        Form --> FormField : fields
+    }
+
+    Command --> Form : form
+    Command --> Class : contextType
+    Command --> Class : targetType
+}
+
+' =============================================================================
+' PRESENTATION LAYER (Platform-Specific)
+' =============================================================================
+package "presentation/obsidian" <<Rectangle>> #FFEBEE {
+
+    package "layouts" {
+        class "layout__Layout" as Layout {
+            + targetType : Class
+            + sections : String[]
+            + isDefault : Boolean
+            --
+            Визуальный шаблон
+        }
+
+        class "layout__TaskLayout" as TaskLayout
+
+        TaskLayout --|> Layout
+        Layout --> Class : targetType
+    }
+
+    package "groundings" {
+        class "grnd__Grounding" as Grounding {
+            + command : Command
+            + platform : String
+            + status : String
+            + capabilities : String[]
+            --
+            Привязка к платформе
+        }
+
+        class "grnd__CreateTaskGrounding" as CreateTaskGrounding
+
+        CreateTaskGrounding --|> Grounding
+        Grounding --> Command : command
+    }
+}
+
+' =============================================================================
+' LAYER DEPENDENCIES (Clean Architecture)
+' =============================================================================
+note "Layer Dependencies:\ncore ← meta ← domain ← application ← presentation" as N1
+
+@enduml


### PR DESCRIPTION
## Summary

Added UML class diagram showing the ontology architecture.

### Files Added

- `docs/class-diagram.puml` - PlantUML version for detailed viewing/editing
- Mermaid diagram in `README.md` - renders directly on GitHub

### Diagram Contents

Shows all 5 layers of Clean Architecture:

| Layer | Classes |
|-------|---------|
| **core** | Resource, Asset, Reference, Relation, Class, Property, ObjectProperty, DatatypeProperty, StringProperty, NumberProperty, BooleanProperty, DateProperty, DateTimeProperty, Ontology |
| **meta** | MetaClass, MetaProperty, Constraint, Cardinality |
| **domain/ems** | Effort (mixin), Task, Project, Area, Prototype |
| **application** | Command, CreateTask, StartTask, CompleteTask, Search, Form, FormField, LinkField |
| **presentation** | Layout, TaskLayout, Grounding, CreateTaskGrounding |

## Test plan

- [x] Mermaid diagram renders on GitHub
- [x] PlantUML file is valid syntax