### PR TITLE
refactor: remove redundant core__Class_superClass: core__Asset

### DIFF
--- a/03 Knowledge/core/core__Ontology.md
+++ b/03 Knowledge/core/core__Ontology.md
@@ -1,9 +1,7 @@
 ---
-core__Asset_uid: a1b2c3d4-core-0001-0000-000000000011
+core__Asset_uid: a1b2c3d4-core-0014-0000-000000000001
 core__Asset_isDefinedBy: "[[!core]]"
 core__Instance_class:
   - "[[core__Class]]"
-core__Class_superClass:
-  - "[[core__Asset]]"
-core__Class_description: Онтология - набор связанных классов и свойств
+core__Class_description: Онтология - набор классов и свойств для описания предметной области
 ---

--- a/03 Knowledge/core/core__Prototype.md
+++ b/03 Knowledge/core/core__Prototype.md
@@ -3,7 +3,5 @@ core__Asset_uid: a1b2c3d4-core-0015-0000-000000000001
 core__Asset_isDefinedBy: "[[!core]]"
 core__Instance_class:
   - "[[core__Class]]"
-core__Class_superClass:
-  - "[[core__Asset]]"
 core__Class_description: Шаблон для создания типовых сущностей с предопределёнными значениями свойств
 ---

--- a/03 Knowledge/core/core__Reference.md
+++ b/03 Knowledge/core/core__Reference.md
@@ -3,7 +3,5 @@ core__Asset_uid: a1b2c3d4-core-0003-0000-000000000001
 core__Asset_isDefinedBy: "[[!core]]"
 core__Instance_class:
   - "[[core__Class]]"
-core__Class_superClass:
-  - "[[core__Asset]]"
 core__Class_description: Ссылка на другой Asset
 ---

--- a/03 Knowledge/domain/ems/ems__Area.md
+++ b/03 Knowledge/domain/ems/ems__Area.md
@@ -3,7 +3,5 @@ core__Asset_uid: c3d4e5f6-ems0-0004-0000-000000000001
 core__Asset_isDefinedBy: "[[!ems]]"
 core__Instance_class:
   - "[[core__Class]]"
-core__Class_superClass:
-  - "[[core__Asset]]"
 core__Class_description: Область ответственности - бессрочная категория для задач и проектов
 ---

--- a/03 Knowledge/domain/ems/ems__Project.md
+++ b/03 Knowledge/domain/ems/ems__Project.md
@@ -3,7 +3,5 @@ core__Asset_uid: c3d4e5f6-ems0-0003-0000-000000000001
 core__Asset_isDefinedBy: "[[!ems]]"
 core__Instance_class:
   - "[[core__Class]]"
-core__Class_superClass:
-  - "[[core__Asset]]"
 core__Class_description: Проект - контейнер для связанных задач с общей целью
 ---

--- a/03 Knowledge/domain/ems/ems__Prototype.md
+++ b/03 Knowledge/domain/ems/ems__Prototype.md
@@ -3,7 +3,5 @@ core__Asset_uid: c3d4e5f6-ems0-0005-0000-000000000001
 core__Asset_isDefinedBy: "[[!ems]]"
 core__Instance_class:
   - "[[core__Class]]"
-core__Class_superClass:
-  - "[[core__Asset]]"
 core__Class_description: Прототип - шаблон для создания однотипных задач
 ---

--- a/03 Knowledge/domain/ems/ems__Task.md
+++ b/03 Knowledge/domain/ems/ems__Task.md
@@ -4,7 +4,6 @@ core__Asset_isDefinedBy: "[[!ems]]"
 core__Instance_class:
   - "[[core__Class]]"
 core__Class_superClass:
-  - "[[core__Asset]]"
   - "[[ems__Effort]]"
 core__Class_description: Задача - единица работы с временными рамками
 ---


### PR DESCRIPTION
## Summary

`core__Asset` is the default superClass (implicit inheritance root), so specifying it explicitly is redundant.

## Files Changed

- `core/core__Prototype.md` — removed
- `core/core__Reference.md` — removed  
- `core/core__Ontology.md` — removed
- `domain/ems/ems__Area.md` — removed
- `domain/ems/ems__Project.md` — removed
- `domain/ems/ems__Prototype.md` — removed
- `domain/ems/ems__Task.md` — removed `core__Asset`, kept `ems__Effort`

## Stats

- **7 files changed**
- **2 insertions, 15 deletions**