### PR TITLE
refactor: remove redundant core__Reference class

### DIFF
--- a/03 Knowledge/core/core__Reference.md
+++ b/03 Knowledge/core/core__Reference.md
@@ -1,7 +1,0 @@
----
-core__Asset_uid: a1b2c3d4-core-0003-0000-000000000001
-core__Asset_isDefinedBy: "[[!core]]"
-core__Instance_class:
-  - "[[core__Class]]"
-core__Class_description: Ссылка на другой Asset
----


### PR DESCRIPTION
## Summary

- Удалён избыточный класс `core__Reference`
- Его семантика ("ссылка на другой Asset") полностью покрывается `core__ObjectProperty`

## Test plan

- [x] Проверить, что файл удалён
- [ ] Убедиться, что нет ссылок на `core__Reference` в других файлах