### PR TITLE
docs: update README with correct triple file format

### DIFF
--- a/03 Knowledge/README.md
+++ b/03 Knowledge/README.md
@@ -17,6 +17,21 @@ Each RDF triple is represented as a separate file with the format:
 {subject} {predicate} {object}.md
 ```
 
+Triple files contain YAML frontmatter with reified statement structure:
+```yaml
+---
+rdf:type: "[[rdf__Statement]]"
+rdf:subject: "[[{subject}]]"
+rdf:predicate: "[[{predicate}]]"
+rdf:object: "[[{object}]]"
+---
+```
+
+For literal values, `rdf:object` contains the literal without wikilinks:
+```yaml
+rdf:object: "Class"
+```
+
 Examples:
 - `rdfs__Class a rdfs__Class.md` — type declaration (`rdf:type`)
 - `rdfs__Class rdfs__label "Class".md` — literal value
@@ -35,8 +50,8 @@ These files contain the `!` property with the ontology URL.
 
 - `__` (double underscore) replaces `:` in prefixed names: `rdfs:Class` → `rdfs__Class`
 - `a` is used as shorthand for `rdf:type` (standard SPARQL/Turtle syntax)
-- Literal values are quoted: `"Class"`, `"The class of classes."`
-- Resource references are unquoted: `rdfs__Resource`
+- Literal values are quoted in filename: `"Class"`, `"The class of classes."`
+- Resource references are unquoted in filename: `rdfs__Resource`
 
 ## Example
 
@@ -51,9 +66,29 @@ Files:
 ```
 rdfs/
 ├── rdfs__Class.md                              (empty - resource anchor)
-├── rdfs__Class a rdfs__Class.md                (empty - type triple)
-├── rdfs__Class rdfs__label "Class".md          (empty - label triple)
-├── rdfs__Class rdfs__subClassOf rdfs__Resource.md  (empty - subclass triple)
+├── rdfs__Class a rdfs__Class.md                (frontmatter with reified triple)
+├── rdfs__Class rdfs__label "Class".md          (frontmatter with reified triple)
+├── rdfs__Class rdfs__subClassOf rdfs__Resource.md  (frontmatter with reified triple)
 ```
 
-All triple files are empty — the information is encoded in the filename itself.
+### Triple File Content Example
+
+File `rdfs__Class a rdfs__Class.md`:
+```yaml
+---
+rdf:type: "[[rdf__Statement]]"
+rdf:subject: "[[rdfs__Class]]"
+rdf:predicate: "[[rdf__type|a]]"
+rdf:object: "[[rdfs__Class]]"
+---
+```
+
+File `rdfs__Class rdfs__label "Class".md`:
+```yaml
+---
+rdf:type: "[[rdf__Statement]]"
+rdf:subject: "[[rdfs__Class]]"
+rdf:predicate: "[[rdfs__label]]"
+rdf:object: "Class"
+---
+```


### PR DESCRIPTION
## Summary

Updates README documentation to accurately describe the triple file format.

## Changes

- Corrected documentation: triple files contain YAML frontmatter, not empty
- Added frontmatter structure example with `rdf:type`, `rdf:subject`, `rdf:predicate`, `rdf:object`
- Added concrete examples showing both resource reference and literal value cases
- Clarified that only resource files are empty, triple files have content

## Test plan

- [x] Verify documentation matches actual file content